### PR TITLE
Add link to new Khronos slides and new ImgTech demo

### DIFF
--- a/index.html
+++ b/index.html
@@ -141,6 +141,14 @@
                 Vulkan.
             </p>
 
+            <p>
+                On August 2015, Khronos released new slides about Vulkan; the main announcements are: Google will support Vulkan on the next version of Android,
+                Vulkan will support "feature sets" to group together features under a single name, and Vulkan Conformance Tests will be developed together with
+                Google and the Android Open Source Project (AOSP) and they will be open source.
+                <br>More details <a href="http://www.anandtech.com/show/9509/vulkan-status-update-will-use-feature-sets-android-support-incoming">here</a>
+                and <a href="http://www.phoronix.com/scan.php?page=article&item=sig-gles32-glu&num=4">here</a>.
+            </p>
+
             <h1>SPIR-V</h1>
 
             <p>
@@ -193,6 +201,14 @@
 
             <p>
                 <iframe width="700" height="394" src="https://www.youtube.com/embed/0Hth4u65zfc" frameborder="0" allowfullscreen></iframe>
+            </p>
+
+            On August 10, 2015 <a href="http://imgtec.com/">Imagination Technologies</a> released a new demo comparing Vulkan and OpenGL ES.
+            On their <a href="http://blog.imgtec.com/powervr/gnomes-per-second-in-vulkan-and-opengl-es">blog</a>
+            they provided a rough technical explanation about the performance advantages in using Vulkan.
+
+            <p>
+                <iframe width="700" height="394" src="https://www.youtube.com/embed/P_I8an8jXuM" frameborder="0" allowfullscreen></iframe>
             </p>
         </article>
 


### PR DESCRIPTION
Khronos released new slides about Vulkan; I couldn't find a link to the original slides, so I linked two articles by Anandtech and Phoronix.

ImgTech also released a new demo, so I linked that video as well.