### PR TITLE
Code improvement for intermediate isDeviceSuitable

### DIFF
--- a/03_Drawing_a_triangle/00_Setup/03_Physical_devices_and_queue_families.md
+++ b/03_Drawing_a_triangle/00_Setup/03_Physical_devices_and_queue_families.md
@@ -114,8 +114,8 @@ function would look like this:
 bool isDeviceSuitable(VkPhysicalDevice device) {
     VkPhysicalDeviceProperties deviceProperties;
     VkPhysicalDeviceFeatures deviceFeatures;
-    vkGetPhysicalDeviceProperties(physicalDevice, &deviceProperties);
-    vkGetPhysicalDeviceFeatures(physicalDevice, &deviceFeatures);
+    vkGetPhysicalDeviceProperties(device, &deviceProperties);
+    vkGetPhysicalDeviceFeatures(device, &deviceFeatures);
 
     return deviceProperties.deviceType == VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU &&
            deviceFeatures.geometryShader;


### PR DESCRIPTION
In one of the early, intermediate representations of isDeviceSuitable
the code uses the class variable 'physicalDevice' instead of the
argument passed in, 'device'.

Even though this code is iterated on, and not in the final version
presented in this section, using the proper variable makes this
code easier to follow.