### PR TITLE
Use C++11 in-class initialization in VDeleter

### DIFF
--- a/code/hello_triangle.cpp
+++ b/code/hello_triangle.cpp
@@ -49,17 +49,14 @@ public:
     VDeleter() : VDeleter([](T _) {}) {}
 
     VDeleter(std::function<void(T, VkAllocationCallbacks*)> deletef) {
-        object = VK_NULL_HANDLE;
         this->deleter = [=](T obj) { deletef(obj, nullptr); };
     }
 
     VDeleter(const VDeleter<VkInstance>& instance, std::function<void(VkInstance, T, VkAllocationCallbacks*)> deletef) {
-        object = VK_NULL_HANDLE;
         this->deleter = [&instance, deletef](T obj) { deletef(instance, obj, nullptr); };
     }
 
     VDeleter(const VDeleter<VkDevice>& device, std::function<void(VkDevice, T, VkAllocationCallbacks*)> deletef) {
-        object = VK_NULL_HANDLE;
         this->deleter = [&device, deletef](T obj) { deletef(device, obj, nullptr); };
     }
 
@@ -77,7 +74,7 @@ public:
     }
 
 private:
-    T object;
+    T object{ VK_NULL_HANDLE };
     std::function<void(T)> deleter;
 
     void cleanup() {


### PR DESCRIPTION
Since these tutorials are for C++11, I would like to suggest a change to improve the code.

The VDeleter class template has 3 constructors (for different kinds of objects), and they all have the same first line:
```
object = VK_NULL_HANDLE;
```

This change skips copying the same line 3 times, by moving everything to one line.
```
T object{ VK_NULL_HANDLE };
```
For more info: http://en.cppreference.com/w/cpp/language/data_members#Member_initialization