### PR TITLE
Fix incorrect function name in example

### DIFF
--- a/03_Drawing_a_triangle/00_Setup/02_Validation_layers.md
+++ b/03_Drawing_a_triangle/00_Setup/02_Validation_layers.md
@@ -262,7 +262,7 @@ this handle right under `instance`:
 VkDebugReportCallbackEXT callback;
 ```
 
-Now add a function `createDebugCallback` to be called from `initVulkan` right
+Now add a function `setupDebugCallback` to be called from `initVulkan` right
 after `createInstance`:
 
 ```c++


### PR DESCRIPTION
There was a typo in the paragraph above the code example: `setupDebugCallback` != `createDebugCallback`

This fixes it.