### PR TITLE
Load models section needs vertex colors

### DIFF
--- a/08_Loading_models.md
+++ b/08_Loading_models.md
@@ -207,6 +207,8 @@ vertex.texCoord = {
     attrib.texcoords[2 * index.texcoord_index + 0],
     attrib.texcoords[2 * index.texcoord_index + 1]
 };
+
+vertex.color = {1.0f, 1.0f, 1.0f};
 ```
 
 Unfortunately the `attrib.vertices` array is an array of `float` values instead

--- a/code/model_loading.cpp
+++ b/code/model_loading.cpp
@@ -1002,6 +1002,8 @@ private:
                     1.0f - attrib.texcoords[2 * index.texcoord_index + 1]
                 };
 
+                vertex.color = {1.0f, 1.0f, 1.0f};
+
                 if (uniqueVertices.count(vertex) == 0) {
                     uniqueVertices[vertex] = vertices.size();
                     vertices.push_back(vertex);


### PR DESCRIPTION
When running the given examples I had an all black screen.
I realized the shader was still multiplying the texture and vertex
colors. This sets each color to white as they are loaded from the obj.

An alternative solution would be to modify the fragment shader,
but felt it was better to provide proper Vertex attributes.
