### PR TITLE
Update 02_Validation_layers.md

### DIFF
--- a/03_Drawing_a_triangle/00_Setup/02_Validation_layers.md
+++ b/03_Drawing_a_triangle/00_Setup/02_Validation_layers.md
@@ -315,7 +315,7 @@ couldn't be loaded. We can now call this function to create the extension
 object if it's available:
 
 ```c++
-if (CreateDebugReportCallbackEXT(instance, &createInfo, nullptr, callback) != VK_SUCCESS) {
+if (CreateDebugReportCallbackEXT(instance, &createInfo, nullptr, &callback) != VK_SUCCESS) {
     throw std::runtime_error("failed to set up debug callback!");
 }
 ```


### PR DESCRIPTION
The address of the callback should be passed to the `CreateDebugReportCallbackEXT` function instead of the callback itself, otherwise it doesn't compile.