### PR TITLE
Fix device scoring example and a typo

### DIFF
--- a/03_Drawing_a_triangle/00_Setup/03_Physical_devices_and_queue_families.md
+++ b/03_Drawing_a_triangle/00_Setup/03_Physical_devices_and_queue_families.md
@@ -103,7 +103,7 @@ VkPhysicalDeviceFeatures deviceFeatures;
 vkGetPhysicalDeviceFeatures(physicalDevice, &deviceFeatures);
 ```
 
-There more details that can be queried from devices that we'll discuss later
+There are more details that can be queried from devices that we'll discuss later
 concerning device memory and queue families (see the next section).
 
 As an example, let's say we consider our application only usable for dedicated
@@ -137,16 +137,16 @@ void pickPhysicalDevice() {
     ...
 
     // Use an ordered map to automatically sort candidates by increasing score
-    std::map<int, VkPhysicalDevice> candidates;
+    std::multimap<int, VkPhysicalDevice> candidates;
 
     for (const auto& device : devices) {
         int score = rateDeviceSuitability(device);
-        candidates[score] = device;
+        candidates.insert(std::make_pair(score, device));
     }
 
     // Check if the best candidate is suitable at all
-    if (candidates.begin()->first > 0) {
-        physicalDevice = candidates.begin()->second;
+    if (candidates.rbegin()->first > 0) {
+        physicalDevice = candidates.rbegin()->second;
     } else {
         throw std::runtime_error("failed to find a suitable GPU!");
     }


### PR DESCRIPTION
This fixes a typo where something like "are" seems to be missing.

Furthermore, it seems to me that the device scoring example on the same page is broken since std::map will sort the devices in order of increasing score (as stated in the example), but then the "best" device is accessed using ```candidates.begin()```, which will return the device with the lowest score. Thus, it will actually return the worst device. I changed it to use ```candidates.rbegin()``` to access the best device instead. While at it, I would also propose to use a ```std::multimap``` here such that multiple devices with the same score won't get merged into a single map entry (might potentially be useful if one wants to optionally show the sorted device list to the user, for example). ```std::multimap``` does not seem to have the [] operator, thus the change to ```insert()```.