### PR TITLE
Fix link references so that the Daux static file generator works

### DIFF
--- a/02_Development_environment.md
+++ b/02_Development_environment.md
@@ -210,7 +210,7 @@ chapter.
 
 ![](/images/vs_template.png)
 
-You are now all set for [the real adventure](!Drawing_a_triangle).
+You are now all set for [the real adventure](!Drawing_a_triangle/Setup/Base_code).
 
 ## Linux
 
@@ -500,4 +500,4 @@ The `Doc` directory contains useful information about the Vulkan SDK and an
 offline version of the entire Vulkan specification. Feel free to explore the
 other files, but we won't need them for this tutorial.
 
-You are now all set for [the real adventure](!Drawing_a_triangle).
+You are now all set for [the real adventure](!Drawing_a_triangle/Setup/Base_code).


### PR DESCRIPTION
Resolving `[text](!other_page)` links appears to be more lenient in live-serving mode, where if you give it a base directory and not a leaf file it works (figuring out the leaf file on the fly). However this breaks static generation because it complains it can't find the directory as a doc file.

This pull request fixes two "broken" links in the tutorial by pointing them at the first leaf file in the sub-directory hierarchy instead of at the base directory. It has no affect on the live serving because we simply made the link more accurate.