### PR TITLE
VK_IMAGE_TILING_LINEAR to VK_IMAGE_TILING_OPTIMAL

### DIFF
--- a/06_Texture_mapping/00_Images.md
+++ b/06_Texture_mapping/00_Images.md
@@ -222,7 +222,7 @@ for the texels as the pixels in the buffer, otherwise the copy operation will
 fail.
 
 ```c++
-imageInfo.tiling = VK_IMAGE_TILING_LINEAR;
+imageInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
 ```
 
 The `tiling` field can have one of two values:


### PR DESCRIPTION
in the text it says we'll be using VK_IMAGE_TILING_OPTIMAL, but the code had it set to VK_IMAGE_TILING_LINEAR. Also the code further down the page has it set to VK_IMAGE_TILING_OPTIMAL.