### PR TITLE
Small change in the text that introduces swap chains

### DIFF
--- a/03_Drawing_a_triangle/01_Presentation/01_Swap_chain.md
+++ b/03_Drawing_a_triangle/01_Presentation/01_Swap_chain.md
@@ -1,4 +1,4 @@
-In this chapter we will look at the infrastructure that gives you the images you can either render to or that can be presented to the screen, generally after being drawn. This infrastructure is
+Vulkan does not have the concept of a "default framebuffer", hence it requires an infrastructure that will own the buffers we will render to before we visualize them on the screen. This infrastructure is
 known as the *swap chain* and must be created explicitly in Vulkan. The swap
 chain is essentially a queue of images that are waiting to be presented to the
 screen. Our application will acquire such an image to draw to it, and then

--- a/03_Drawing_a_triangle/01_Presentation/01_Swap_chain.md
+++ b/03_Drawing_a_triangle/01_Presentation/01_Swap_chain.md
@@ -1,5 +1,4 @@
-In this chapter we will look at the infrastructure that gives you images to
-render to that can be presented to the screen afterwards. This infrastructure is
+In this chapter we will look at the infrastructure that gives you the images you can either render to or that can be presented to the screen, generally after being drawn. This infrastructure is
 known as the *swap chain* and must be created explicitly in Vulkan. The swap
 chain is essentially a queue of images that are waiting to be presented to the
 screen. Our application will acquire such an image to draw to it, and then


### PR DESCRIPTION
I was quite puzzled by the words <<images to render to that>>, maybe because I am not a native but it took me more than one read to understand it :D This is a proposed change, maybe not the best, but I am opening the PR so that maybe you can evaluate whether to change the sentence in some way or not. A minor thing but the quality of the tutorials is pretty high hence I hope it's not a problem I am raising even smaller issues.