### PR TITLE
Fix type inconsistency.

### DIFF
--- a/03_Drawing_a_triangle/00_Setup/01_Instance.md
+++ b/03_Drawing_a_triangle/00_Setup/01_Instance.md
@@ -62,7 +62,7 @@ the window system. GLFW has a handy built-in function that returns the
 extension(s) it needs to do that which we can pass to the struct:
 
 ```c++
-unsigned int glfwExtensionCount = 0;
+uint32_t glfwExtensionCount = 0;
 const char** glfwExtensions;
 
 glfwExtensions = glfwGetRequiredInstanceExtensions(&glfwExtensionCount);

--- a/03_Drawing_a_triangle/00_Setup/02_Validation_layers.md
+++ b/03_Drawing_a_triangle/00_Setup/02_Validation_layers.md
@@ -180,11 +180,11 @@ not:
 std::vector<const char*> getRequiredExtensions() {
     std::vector<const char*> extensions;
 
-    unsigned int glfwExtensionCount = 0;
+    uint32_t glfwExtensionCount = 0;
     const char** glfwExtensions;
     glfwExtensions = glfwGetRequiredInstanceExtensions(&glfwExtensionCount);
 
-    for (unsigned int i = 0; i < glfwExtensionCount; i++) {
+    for (uint32_t i = 0; i < glfwExtensionCount; i++) {
         extensions.push_back(glfwExtensions[i]);
     }
 


### PR DESCRIPTION
glfwGetRequiredInstanceExtensions takes a uint32_t, and it's best for portable code to be explicit in its types.

Similar code in this section also explicitly uses uint32_t