### PR TITLE
Depth buffering recreateSwapChain example missing call to cleanupSwapChain

### DIFF
--- a/07_Depth_buffering.md
+++ b/07_Depth_buffering.md
@@ -548,6 +548,8 @@ function to recreate the depth resources in that case:
 ```c++
 void recreateSwapChain() {
     vkDeviceWaitIdle(device);
+    
+    cleanupSwapChain();
 
     createSwapChain();
     createImageViews();


### PR DESCRIPTION
The call to cleanupSwapChain was missing in the example for recreateSwapChain  at the end of the depth buffering page.