### PR TITLE
04_Conclusion.md: Clarify vkCreateGraphicsPipeline location

### DIFF
--- a/03_Drawing_a_triangle/02_Graphics_pipeline_basics/04_Conclusion.md
+++ b/03_Drawing_a_triangle/02_Graphics_pipeline_basics/04_Conclusion.md
@@ -13,7 +13,8 @@ be updated at draw time
 
 All of these combined fully define the functionality of the graphics pipeline,
 so we can now begin filling in the `VkGraphicsPipelineCreateInfo` structure at
-the end of the `createGraphicsPipeline` function.
+the end of the `createGraphicsPipeline` function. But before the calls to 
+`vkDestroyShaderModule` because these are still to be used during the creation.
 
 ```c++
 VkGraphicsPipelineCreateInfo pipelineInfo = {};


### PR DESCRIPTION
The original text mentions to add the VkGraphicsPipelineCreateInfo & vkCreateGraphicsPipelines() at the end of createGraphicsPipeline(). However they should be called before the calls to vkDestroyshaderModule as these are referenced inside the pipelineInfo struct. If you add them at the end (after the destruction, and as the text mentions) you'll get errors like: 

(null)(ERROR / SPEC): msgNum: 274780673 - Invalid ShaderModule Object 0xa. The spec valid usage text states 'module must be a valid VkShaderModule handle' (https://www.khronos.org/registry/vulkan/specs/1.0/html/vkspec.html#VUID-VkPipelineShaderStageCreateInfo-module-parameter)
    Objects: 1
       [0] 0xa, type: 15, name: (null)