### PR TITLE
Clarify location to call vkCmdBindDescriptorSets

### DIFF
--- a/05_Uniform_buffers/01_Descriptor_pool_and_sets.md
+++ b/05_Uniform_buffers/01_Descriptor_pool_and_sets.md
@@ -199,10 +199,12 @@ as its name implies.
 ## Using a descriptor set
 
 We now need to update the `createCommandBuffers` function to actually bind the
-descriptor set to the descriptors in the shader with `cmdBindDescriptorSets`:
+descriptor set to the descriptors in the shader with `cmdBindDescriptorSets`,
+this needs to be done before the `vkCmdDrawIndexed` call:
 
 ```c++
 vkCmdBindDescriptorSets(commandBuffers[i], VK_PIPELINE_BIND_POINT_GRAPHICS, pipelineLayout, 0, 1, &descriptorSet, 0, nullptr);
+vkCmdDrawIndexed(commandBuffers[i], static_cast<uint32_t>(indices.size()), 1, 0, 0, 0);
 ```
 
 Unlike vertex and index buffers, descriptor sets are not unique to graphics


### PR DESCRIPTION
The call to vkCmdBindDescriptorSets() needs to happen before vkCmdDrawIndex() otherwise runtime errors might appear like:

Validation(ERROR): msg_code: 62: Object: 0x555e4d0ebac0 (Type = 6) | VkPipeline 0xe uses set #0 but that set is not bound.

Add some extra context to make this more explicit.