### PR TITLE
Highlighted enabling device extensions section

### DIFF
--- a/03_Drawing_a_triangle/01_Presentation/01_Swap_chain.md
+++ b/03_Drawing_a_triangle/01_Presentation/01_Swap_chain.md
@@ -80,7 +80,10 @@ as we checked in the previous chapter, implies that the swap chain extension
 must be supported. However, it's still good to be explicit about things, and
 the extension does have to be explicitly enabled.
 
-Enabling the extension just requires a small change to the logical device
+## Enabling device extensions
+
+Using a swapchain requires enabling the `VK_KHR_swapchain` extension first. 
+Enabling the extension just requires a small change to the logical device 
 creation structure:
 
 ```c++


### PR DESCRIPTION
Thank you for the tutorial I've finally got my triangle on screen. 🙂 
However I've sucked with swapchain initialization with vulkansdk 1.1.85.0 because debug layers didn't tell me about missed extension during debug initialization and I've gone wrong way because was thinking that the problem is in MoltenVK.
So, at the end I rolled back to 1.1.77.0 and debug layers showed me the problem. So, I decided to highlight this step  to help future adventurers. 🙂 