### PR TITLE
Code: Use uint32_t for WIDTH and HEIGHT to prevent narrowing conversion

### DIFF
--- a/code/00_base_code.cpp
+++ b/code/00_base_code.cpp
@@ -5,8 +5,8 @@
 #include <stdexcept>
 #include <cstdlib>
 
-const int WIDTH = 800;
-const int HEIGHT = 600;
+const uint32_t WIDTH = 800;
+const uint32_t HEIGHT = 600;
 
 class HelloTriangleApplication {
 public:

--- a/code/01_instance_creation.cpp
+++ b/code/01_instance_creation.cpp
@@ -5,8 +5,8 @@
 #include <stdexcept>
 #include <cstdlib>
 
-const int WIDTH = 800;
-const int HEIGHT = 600;
+const uint32_t WIDTH = 800;
+const uint32_t HEIGHT = 600;
 
 class HelloTriangleApplication {
 public:

--- a/code/02_validation_layers.cpp
+++ b/code/02_validation_layers.cpp
@@ -7,8 +7,8 @@
 #include <cstring>
 #include <cstdlib>
 
-const int WIDTH = 800;
-const int HEIGHT = 600;
+const uint32_t WIDTH = 800;
+const uint32_t HEIGHT = 600;
 
 const std::vector<const char*> validationLayers = {
     "VK_LAYER_KHRONOS_validation"

--- a/code/03_physical_device_selection.cpp
+++ b/code/03_physical_device_selection.cpp
@@ -8,8 +8,8 @@
 #include <cstdlib>
 #include <optional>
 
-const int WIDTH = 800;
-const int HEIGHT = 600;
+const uint32_t WIDTH = 800;
+const uint32_t HEIGHT = 600;
 
 const std::vector<const char*> validationLayers = {
     "VK_LAYER_KHRONOS_validation"

--- a/code/04_logical_device.cpp
+++ b/code/04_logical_device.cpp
@@ -8,8 +8,8 @@
 #include <cstdlib>
 #include <optional>
 
-const int WIDTH = 800;
-const int HEIGHT = 600;
+const uint32_t WIDTH = 800;
+const uint32_t HEIGHT = 600;
 
 const std::vector<const char*> validationLayers = {
     "VK_LAYER_KHRONOS_validation"

--- a/code/05_window_surface.cpp
+++ b/code/05_window_surface.cpp
@@ -9,8 +9,8 @@
 #include <optional>
 #include <set>
 
-const int WIDTH = 800;
-const int HEIGHT = 600;
+const uint32_t WIDTH = 800;
+const uint32_t HEIGHT = 600;
 
 const std::vector<const char*> validationLayers = {
     "VK_LAYER_KHRONOS_validation"

--- a/code/06_swap_chain_creation.cpp
+++ b/code/06_swap_chain_creation.cpp
@@ -11,8 +11,8 @@
 #include <optional>
 #include <set>
 
-const int WIDTH = 800;
-const int HEIGHT = 600;
+const uint32_t WIDTH = 800;
+const uint32_t HEIGHT = 600;
 
 const std::vector<const char*> validationLayers = {
     "VK_LAYER_KHRONOS_validation"

--- a/code/07_image_views.cpp
+++ b/code/07_image_views.cpp
@@ -11,8 +11,8 @@
 #include <optional>
 #include <set>
 
-const int WIDTH = 800;
-const int HEIGHT = 600;
+const uint32_t WIDTH = 800;
+const uint32_t HEIGHT = 600;
 
 const std::vector<const char*> validationLayers = {
     "VK_LAYER_KHRONOS_validation"

--- a/code/08_graphics_pipeline.cpp
+++ b/code/08_graphics_pipeline.cpp
@@ -11,8 +11,8 @@
 #include <optional>
 #include <set>
 
-const int WIDTH = 800;
-const int HEIGHT = 600;
+const uint32_t WIDTH = 800;
+const uint32_t HEIGHT = 600;
 
 const std::vector<const char*> validationLayers = {
     "VK_LAYER_KHRONOS_validation"

--- a/code/09_shader_modules.cpp
+++ b/code/09_shader_modules.cpp
@@ -12,8 +12,8 @@
 #include <optional>
 #include <set>
 
-const int WIDTH = 800;
-const int HEIGHT = 600;
+const uint32_t WIDTH = 800;
+const uint32_t HEIGHT = 600;
 
 const std::vector<const char*> validationLayers = {
     "VK_LAYER_KHRONOS_validation"

--- a/code/10_fixed_functions.cpp
+++ b/code/10_fixed_functions.cpp
@@ -12,8 +12,8 @@
 #include <optional>
 #include <set>
 
-const int WIDTH = 800;
-const int HEIGHT = 600;
+const uint32_t WIDTH = 800;
+const uint32_t HEIGHT = 600;
 
 const std::vector<const char*> validationLayers = {
     "VK_LAYER_KHRONOS_validation"

--- a/code/11_render_passes.cpp
+++ b/code/11_render_passes.cpp
@@ -12,8 +12,8 @@
 #include <optional>
 #include <set>
 
-const int WIDTH = 800;
-const int HEIGHT = 600;
+const uint32_t WIDTH = 800;
+const uint32_t HEIGHT = 600;
 
 const std::vector<const char*> validationLayers = {
     "VK_LAYER_KHRONOS_validation"

--- a/code/12_graphics_pipeline_complete.cpp
+++ b/code/12_graphics_pipeline_complete.cpp
@@ -12,8 +12,8 @@
 #include <optional>
 #include <set>
 
-const int WIDTH = 800;
-const int HEIGHT = 600;
+const uint32_t WIDTH = 800;
+const uint32_t HEIGHT = 600;
 
 const std::vector<const char*> validationLayers = {
     "VK_LAYER_KHRONOS_validation"

--- a/code/13_framebuffers.cpp
+++ b/code/13_framebuffers.cpp
@@ -12,8 +12,8 @@
 #include <optional>
 #include <set>
 
-const int WIDTH = 800;
-const int HEIGHT = 600;
+const uint32_t WIDTH = 800;
+const uint32_t HEIGHT = 600;
 
 const std::vector<const char*> validationLayers = {
     "VK_LAYER_KHRONOS_validation"

--- a/code/14_command_buffers.cpp
+++ b/code/14_command_buffers.cpp
@@ -12,8 +12,8 @@
 #include <optional>
 #include <set>
 
-const int WIDTH = 800;
-const int HEIGHT = 600;
+const uint32_t WIDTH = 800;
+const uint32_t HEIGHT = 600;
 
 const std::vector<const char*> validationLayers = {
     "VK_LAYER_KHRONOS_validation"

--- a/code/15_hello_triangle.cpp
+++ b/code/15_hello_triangle.cpp
@@ -12,8 +12,8 @@
 #include <optional>
 #include <set>
 
-const int WIDTH = 800;
-const int HEIGHT = 600;
+const uint32_t WIDTH = 800;
+const uint32_t HEIGHT = 600;
 
 const int MAX_FRAMES_IN_FLIGHT = 2;
 

--- a/code/16_swap_chain_recreation.cpp
+++ b/code/16_swap_chain_recreation.cpp
@@ -12,8 +12,8 @@
 #include <optional>
 #include <set>
 
-const int WIDTH = 800;
-const int HEIGHT = 600;
+const uint32_t WIDTH = 800;
+const uint32_t HEIGHT = 600;
 
 const int MAX_FRAMES_IN_FLIGHT = 2;
 

--- a/code/17_vertex_input.cpp
+++ b/code/17_vertex_input.cpp
@@ -15,8 +15,8 @@
 #include <optional>
 #include <set>
 
-const int WIDTH = 800;
-const int HEIGHT = 600;
+const uint32_t WIDTH = 800;
+const uint32_t HEIGHT = 600;
 
 const int MAX_FRAMES_IN_FLIGHT = 2;
 

--- a/code/18_vertex_buffer.cpp
+++ b/code/18_vertex_buffer.cpp
@@ -15,8 +15,8 @@
 #include <optional>
 #include <set>
 
-const int WIDTH = 800;
-const int HEIGHT = 600;
+const uint32_t WIDTH = 800;
+const uint32_t HEIGHT = 600;
 
 const int MAX_FRAMES_IN_FLIGHT = 2;
 

--- a/code/19_staging_buffer.cpp
+++ b/code/19_staging_buffer.cpp
@@ -15,8 +15,8 @@
 #include <optional>
 #include <set>
 
-const int WIDTH = 800;
-const int HEIGHT = 600;
+const uint32_t WIDTH = 800;
+const uint32_t HEIGHT = 600;
 
 const int MAX_FRAMES_IN_FLIGHT = 2;
 

--- a/code/20_index_buffer.cpp
+++ b/code/20_index_buffer.cpp
@@ -15,8 +15,8 @@
 #include <optional>
 #include <set>
 
-const int WIDTH = 800;
-const int HEIGHT = 600;
+const uint32_t WIDTH = 800;
+const uint32_t HEIGHT = 600;
 
 const int MAX_FRAMES_IN_FLIGHT = 2;
 

--- a/code/21_descriptor_layout.cpp
+++ b/code/21_descriptor_layout.cpp
@@ -18,8 +18,8 @@
 #include <optional>
 #include <set>
 
-const int WIDTH = 800;
-const int HEIGHT = 600;
+const uint32_t WIDTH = 800;
+const uint32_t HEIGHT = 600;
 
 const int MAX_FRAMES_IN_FLIGHT = 2;
 

--- a/code/22_descriptor_sets.cpp
+++ b/code/22_descriptor_sets.cpp
@@ -18,8 +18,8 @@
 #include <optional>
 #include <set>
 
-const int WIDTH = 800;
-const int HEIGHT = 600;
+const uint32_t WIDTH = 800;
+const uint32_t HEIGHT = 600;
 
 const int MAX_FRAMES_IN_FLIGHT = 2;
 

--- a/code/23_texture_image.cpp
+++ b/code/23_texture_image.cpp
@@ -21,8 +21,8 @@
 #include <optional>
 #include <set>
 
-const int WIDTH = 800;
-const int HEIGHT = 600;
+const uint32_t WIDTH = 800;
+const uint32_t HEIGHT = 600;
 
 const int MAX_FRAMES_IN_FLIGHT = 2;
 

--- a/code/24_sampler.cpp
+++ b/code/24_sampler.cpp
@@ -21,8 +21,8 @@
 #include <optional>
 #include <set>
 
-const int WIDTH = 800;
-const int HEIGHT = 600;
+const uint32_t WIDTH = 800;
+const uint32_t HEIGHT = 600;
 
 const int MAX_FRAMES_IN_FLIGHT = 2;
 

--- a/code/25_texture_mapping.cpp
+++ b/code/25_texture_mapping.cpp
@@ -21,8 +21,8 @@
 #include <optional>
 #include <set>
 
-const int WIDTH = 800;
-const int HEIGHT = 600;
+const uint32_t WIDTH = 800;
+const uint32_t HEIGHT = 600;
 
 const int MAX_FRAMES_IN_FLIGHT = 2;
 

--- a/code/26_depth_buffering.cpp
+++ b/code/26_depth_buffering.cpp
@@ -22,8 +22,8 @@
 #include <optional>
 #include <set>
 
-const int WIDTH = 800;
-const int HEIGHT = 600;
+const uint32_t WIDTH = 800;
+const uint32_t HEIGHT = 600;
 
 const int MAX_FRAMES_IN_FLIGHT = 2;
 

--- a/code/27_model_loading.cpp
+++ b/code/27_model_loading.cpp
@@ -28,8 +28,8 @@
 #include <set>
 #include <unordered_map>
 
-const int WIDTH = 800;
-const int HEIGHT = 600;
+const uint32_t WIDTH = 800;
+const uint32_t HEIGHT = 600;
 
 const std::string MODEL_PATH = "models/chalet.obj";
 const std::string TEXTURE_PATH = "textures/chalet.jpg";

--- a/code/28_mipmapping.cpp
+++ b/code/28_mipmapping.cpp
@@ -28,8 +28,8 @@
 #include <set>
 #include <unordered_map>
 
-const int WIDTH = 800;
-const int HEIGHT = 600;
+const uint32_t WIDTH = 800;
+const uint32_t HEIGHT = 600;
 
 const std::string MODEL_PATH = "models/chalet.obj";
 const std::string TEXTURE_PATH = "textures/chalet.jpg";

--- a/code/29_multisampling.cpp
+++ b/code/29_multisampling.cpp
@@ -28,8 +28,8 @@
 #include <set>
 #include <unordered_map>
 
-const int WIDTH = 800;
-const int HEIGHT = 600;
+const uint32_t WIDTH = 800;
+const uint32_t HEIGHT = 600;
 
 const std::string MODEL_PATH = "models/chalet.obj";
 const std::string TEXTURE_PATH = "textures/chalet.jpg";

--- a/en/03_Drawing_a_triangle/00_Setup/00_Base_code.md
+++ b/en/03_Drawing_a_triangle/00_Setup/00_Base_code.md
@@ -160,8 +160,8 @@ because we'll be referring to these values a couple of times in the future. I've
 added the following lines above the `HelloTriangleApplication` class definition:
 
 ```c++
-const int WIDTH = 800;
-const int HEIGHT = 600;
+const uint32_t WIDTH = 800;
+const uint32_t HEIGHT = 600;
 ```
 
 and replaced the window creation call with

--- a/en/03_Drawing_a_triangle/00_Setup/02_Validation_layers.md
+++ b/en/03_Drawing_a_triangle/00_Setup/02_Validation_layers.md
@@ -76,8 +76,8 @@ whether the program is being compiled in debug mode or not. The `NDEBUG` macro
 is part of the C++ standard and means "not debug".
 
 ```c++
-const int WIDTH = 800;
-const int HEIGHT = 600;
+const uint32_t WIDTH = 800;
+const uint32_t HEIGHT = 600;
 
 const std::vector<const char*> validationLayers = {
     "VK_LAYER_KHRONOS_validation"

--- a/en/08_Loading_models.md
+++ b/en/08_Loading_models.md
@@ -66,8 +66,8 @@ Put two new configuration variables in your program to define the model and
 texture paths:
 
 ```c++
-const int WIDTH = 800;
-const int HEIGHT = 600;
+const uint32_t WIDTH = 800;
+const uint32_t HEIGHT = 600;
 
 const std::string MODEL_PATH = "models/chalet.obj";
 const std::string TEXTURE_PATH = "textures/chalet.jpg";

--- a/fr/03_Dessiner_un_triangle/00_Mise_en_place/00_Code_de_base.md
+++ b/fr/03_Dessiner_un_triangle/00_Mise_en_place/00_Code_de_base.md
@@ -145,8 +145,8 @@ Nous devrions plutôt utiliser des constantes pour la hauteur et la largeur dans
 valeurs dans le futur. J'ai donc ajouté ceci au-dessus de la définition de la classe `HelloTriangleApplication` :
 
 ```c++
-const int WIDTH = 800;
-const int HEIGHT = 600;
+const uint32_t WIDTH = 800;
+const uint32_t HEIGHT = 600;
 ```
 
 et remplacé la création de la fenêtre par :

--- a/fr/03_Dessiner_un_triangle/00_Mise_en_place/02_Validation_layers.md
+++ b/fr/03_Dessiner_un_triangle/00_Mise_en_place/02_Validation_layers.md
@@ -64,8 +64,8 @@ choisi d'effectuer ce choix selon si le programme est compilé en mode debug ou 
 du standard c++ et correspond au second cas.
 
 ```c++
-const int WIDTH = 800;
-const int HEIGHT = 600;
+const uint32_t WIDTH = 800;
+const uint32_t HEIGHT = 600;
 
 const std::vector<const char*> validationLayers = {
     "VK_LAYER_KHRONOS_validation"

--- a/fr/08_Charger_des_modèles.md
+++ b/fr/08_Charger_des_modèles.md
@@ -55,8 +55,8 @@ dossier appelé `models`, et placez l'image dans le dossier `textures`.
 Ajoutez deux variables de configuration pour la localisation du modèle et de la texture :
 
 ```c++
-const int WIDTH = 800;
-const int HEIGHT = 600;
+const uint32_t WIDTH = 800;
+const uint32_t HEIGHT = 600;
 
 const std::string MODEL_PATH = "models/chalet.obj";
 const std::string TEXTURE_PATH = "textures/chalet.jpg";


### PR DESCRIPTION
A warning would otherwise be raised from "Swap chain" onward when using
GCC 9.3.0:
```
g++ -std=c++17 -o HelloTriangle main.cpp `pkg-config --static --libs glfw3` -lvulkan
main.cpp: In member function ‘VkExtent2D HelloTriangleApplication::chooseSwapExtent(const VkSurfaceCapabilitiesKHR&)’:
main.cpp:458:40: warning: narrowing conversion of ‘(int)((HelloTriangleApplication*)this)->HelloTriangleApplication::WIDTH’ from ‘int’ to ‘uint32_t’ {aka ‘unsigned int’} [-Wnarrowing]
  458 |             VkExtent2D actualExtent = {WIDTH, HEIGHT};
      |                                        ^~~~~
main.cpp:458:47: warning: narrowing conversion of ‘(int)((HelloTriangleApplication*)this)->HelloTriangleApplication::HEIGHT’ from ‘int’ to ‘uint32_t’ {aka ‘unsigned int’} [-Wnarrowing]
  458 |             VkExtent2D actualExtent = {WIDTH, HEIGHT};
      |                                               ^~~~~~
```

-----

Note: I've replaced it everywhere, but I only tried it on my own code so far, currently at the end of the "Swap chain" step.