### PR TITLE
Fixed some typos

### DIFF
--- a/en/02_Development_environment.md
+++ b/en/02_Development_environment.md
@@ -566,7 +566,7 @@ It should look like so (obviously, paths will be different depending on where yo
 
 ![](/images/xcode_paths.png)
 
-Now, in the *Build Phases* tab, on **Link Binary With Libraries** we will add both the `glfw3` and the `vulkan` frameworks. To make things easier we will be adding he dynamic libraries in the project (you can check the documentation of these libraries if you want to use the static frameworks).
+Now, in the *Build Phases* tab, on **Link Binary With Libraries** we will add both the `glfw3` and the `vulkan` frameworks. To make things easier we will be adding the dynamic libraries in the project (you can check the documentation of these libraries if you want to use the static frameworks).
 
 * For glfw open the folder `/usr/local/lib` and there you will find a file name like `libglfw.3.x.dylib` ("x" is the library's version number, it might be different depending on when you downloaded the package from Homebrew). Simply drag that file to the Linked Frameworks and Libraries tab on Xcode.
 * For vulkan, go to `vulkansdk/macOS/lib`. Do the same for the file both files `libvulkan.1.dylib` and `libvulkan.1.x.xx.dylib` (where "x" will be the version number of the the SDK you downloaded).

--- a/en/03_Drawing_a_triangle/02_Graphics_pipeline_basics/01_Shader_modules.md
+++ b/en/03_Drawing_a_triangle/02_Graphics_pipeline_basics/01_Shader_modules.md
@@ -398,7 +398,7 @@ void createGraphicsPipeline() {
     VkShaderModule fragShaderModule = createShaderModule(fragShaderCode);
 ```
 
-The cleanup should then happen at the end of the function by adding two calls to `vkDestroyShaderModule`. ALl of the remaining code in this chapter will be inserted before these lines.
+The cleanup should then happen at the end of the function by adding two calls to `vkDestroyShaderModule`. All of the remaining code in this chapter will be inserted before these lines.
 
 ```c++
     ...

--- a/en/04_Vertex_buffers/01_Vertex_buffer_creation.md
+++ b/en/04_Vertex_buffers/01_Vertex_buffer_creation.md
@@ -282,7 +282,7 @@ There are two ways to deal with that problem:
 
 * Use a memory heap that is host coherent, indicated with
 `VK_MEMORY_PROPERTY_HOST_COHERENT_BIT`
-* Call `vkFlushMappedMemoryRanges` to after writing to the mapped memory, and
+* Call `vkFlushMappedMemoryRanges` after writing to the mapped memory, and
 call `vkInvalidateMappedMemoryRanges` before reading from the mapped memory
 
 We went for the first approach, which ensures that the mapped memory always


### PR DESCRIPTION
Here are some typos I found while reading.

Also, I'm not sure if this is intended or not but starting from the `01_Vertex_buffer_creation.md` chapter onwards, there is an unusual indentation in the code line with `    memcpy(data, vertices.data(), (size_t) bufferInfo.size);`, both in that page itself, and in the accompanying C++ code for that page (and all subsequent pages/code samples in the following chapters, AFAIK). I haven't done anything about that since I don't know if this is intended or not.

P.S. Thanks for the amazing tutorial!