### PR TITLE
Remove unused header and improve C++ wording

### DIFF
--- a/en/03_Drawing_a_triangle/00_Setup/00_Base_code.md
+++ b/en/03_Drawing_a_triangle/00_Setup/00_Base_code.md
@@ -9,7 +9,6 @@ from scratch with the following code:
 
 #include <iostream>
 #include <stdexcept>
-#include <functional>
 #include <cstdlib>
 
 class HelloTriangleApplication {
@@ -50,8 +49,7 @@ int main() {
 
 We first include the Vulkan header from the LunarG SDK, which provides the
 functions, structures and enumerations. The `stdexcept` and `iostream` headers
-are included for reporting and propagating errors. The `functional` headers will
-be used for a lambda functions in the resource management section. The `cstdlib`
+are included for reporting and propagating errors. The `cstdlib`
 header provides the `EXIT_SUCCESS` and `EXIT_FAILURE` macros.
 
 The program itself is wrapped into a class where we'll store the Vulkan objects
@@ -76,16 +74,19 @@ private class members that need to be freed at the end in `cleanup`.
 
 Just like each chunk of memory allocated with `malloc` requires a call to
 `free`, every Vulkan object that we create needs to be explicitly destroyed when
-we no longer need it. In modern C++ code it is possible to do automatic resource
-management through the utilities in the `<memory>` header, but I've chosen to be
+we no longer need it. In C++ it is possible to perform automatic resource 
+management using [RAII](https://en.wikipedia.org/wiki/Resource_Acquisition_Is_Initialization) 
+or smart pointers provided in the `<memory>` header. However, I've chosen to be
 explicit about allocation and deallocation of Vulkan objects in this tutorial.
 After all, Vulkan's niche is to be explicit about every operation to avoid
 mistakes, so it's good to be explicit about the lifetime of objects to learn how
 the API works.
 
 After following this tutorial, you could implement automatic resource management
-by overloading `std::shared_ptr` for example. Using [RAII](https://en.wikipedia.org/wiki/Resource_Acquisition_Is_Initialization)
-to your advantage is the recommended approach for larger Vulkan programs, but
+by writing C++ classes that acquire Vulkan objects in their constructor and
+release them in their destructor, or by providing a custom deleter to either
+`std::unique_ptr` or `std::shared_ptr`, depending on your ownership requirements. 
+RAII is the recommended model for larger Vulkan programs, but
 for learning purposes it's always good to know what's going on behind the
 scenes.
 


### PR DESCRIPTION
Thanks for the tutorial. I'm starting to learn Vulkan :) 
I turned on my personal `-Wpedantic` flag and improved some sentences regarding C++, also removed an unused header. 

Rationale:

* `<functional>` is not used anywhere. There's no such thing as a *"lambda function"* in C++ - we have *lambda expressions* which are a core language feature that does **not** require use of the `<functional>` header, and we have `std::function` which is a general-purpose callable object wrapper that **supports** closures generated by *lambda expressions*, but it is not directly related to them. `std::function` is a heavyweight abstraction and it is **not** the type of a closure generated by a *lambda expression* - the latter is an anonymous unique type generated by the compiler.

* "Automatic resource management" is nothing new to modern C++, as it can be implemented through basic RAII usage by creating a `struct` with a simple constructor and destructor. While it is true that it is possible to use `std::unique_ptr` and `std::shared_ptr` for Vulkan object management, that is overkill unless unique or shared ownership semantics are actualy needed. The first choice should be a basic wrapper struct, as it has the least overhead and least flexibility.