### PR TITLE
confusion between before and after in the french translation

### DIFF
--- a/fr/03_Dessiner_un_triangle/02_Pipeline_graphique_basique/03_Render_pass.md
+++ b/fr/03_Dessiner_un_triangle/02_Pipeline_graphique_basique/03_Render_pass.md
@@ -4,7 +4,7 @@ Avant de finaliser la création de la pipeline nous devons informer Vulkan des a
 lors du rendu. Nous devons indiquer combien chaque framebuffer aura de buffers de couleur et de profondeur, combien de 
 samples il faudra utiliser avec chaque frambuffer et comment les utiliser tout au long des opérations de rendu. Toutes
 ces informations sont contenues dans un objet appelé *render pass*. Pour le configurer, créons la fonction
-`createRenderPass`. Appelez cette fonction depuis `initVulkan` après `createGraphicsPipeline`.
+`createRenderPass`. Appelez cette fonction depuis `initVulkan` avant `createGraphicsPipeline`.
 
 ```c++
 void initVulkan() {


### PR DESCRIPTION
hi, i don't really know how to contribute but i have found a little mistake (confusion between before and after in the french translation). It's in the render pass chapter, part "setup".
btw i want to thanks you for all the work you have done.