### PR TITLE
Fix VkSamplerCreateInfo type assignments

### DIFF
--- a/code/24_sampler.cpp
+++ b/code/24_sampler.cpp
@@ -763,7 +763,7 @@ private:
         samplerInfo.addressModeV = VK_SAMPLER_ADDRESS_MODE_REPEAT;
         samplerInfo.addressModeW = VK_SAMPLER_ADDRESS_MODE_REPEAT;
         samplerInfo.anisotropyEnable = VK_TRUE;
-        samplerInfo.maxAnisotropy = 16;
+        samplerInfo.maxAnisotropy = 16.0f;
         samplerInfo.borderColor = VK_BORDER_COLOR_INT_OPAQUE_BLACK;
         samplerInfo.unnormalizedCoordinates = VK_FALSE;
         samplerInfo.compareEnable = VK_FALSE;

--- a/code/25_texture_mapping.cpp
+++ b/code/25_texture_mapping.cpp
@@ -777,7 +777,7 @@ private:
         samplerInfo.addressModeV = VK_SAMPLER_ADDRESS_MODE_REPEAT;
         samplerInfo.addressModeW = VK_SAMPLER_ADDRESS_MODE_REPEAT;
         samplerInfo.anisotropyEnable = VK_TRUE;
-        samplerInfo.maxAnisotropy = 16;
+        samplerInfo.maxAnisotropy = 16.0f;
         samplerInfo.borderColor = VK_BORDER_COLOR_INT_OPAQUE_BLACK;
         samplerInfo.unnormalizedCoordinates = VK_FALSE;
         samplerInfo.compareEnable = VK_FALSE;

--- a/code/26_depth_buffering.cpp
+++ b/code/26_depth_buffering.cpp
@@ -854,7 +854,7 @@ private:
         samplerInfo.addressModeV = VK_SAMPLER_ADDRESS_MODE_REPEAT;
         samplerInfo.addressModeW = VK_SAMPLER_ADDRESS_MODE_REPEAT;
         samplerInfo.anisotropyEnable = VK_TRUE;
-        samplerInfo.maxAnisotropy = 16;
+        samplerInfo.maxAnisotropy = 16.0f;
         samplerInfo.borderColor = VK_BORDER_COLOR_INT_OPAQUE_BLACK;
         samplerInfo.unnormalizedCoordinates = VK_FALSE;
         samplerInfo.compareEnable = VK_FALSE;

--- a/code/27_model_loading.cpp
+++ b/code/27_model_loading.cpp
@@ -861,7 +861,7 @@ private:
         samplerInfo.addressModeV = VK_SAMPLER_ADDRESS_MODE_REPEAT;
         samplerInfo.addressModeW = VK_SAMPLER_ADDRESS_MODE_REPEAT;
         samplerInfo.anisotropyEnable = VK_TRUE;
-        samplerInfo.maxAnisotropy = 16;
+        samplerInfo.maxAnisotropy = 16.0f;
         samplerInfo.borderColor = VK_BORDER_COLOR_INT_OPAQUE_BLACK;
         samplerInfo.unnormalizedCoordinates = VK_FALSE;
         samplerInfo.compareEnable = VK_FALSE;

--- a/code/28_mipmapping.cpp
+++ b/code/28_mipmapping.cpp
@@ -952,15 +952,15 @@ private:
         samplerInfo.addressModeV = VK_SAMPLER_ADDRESS_MODE_REPEAT;
         samplerInfo.addressModeW = VK_SAMPLER_ADDRESS_MODE_REPEAT;
         samplerInfo.anisotropyEnable = VK_TRUE;
-        samplerInfo.maxAnisotropy = 16;
+        samplerInfo.maxAnisotropy = 16.0f;
         samplerInfo.borderColor = VK_BORDER_COLOR_INT_OPAQUE_BLACK;
         samplerInfo.unnormalizedCoordinates = VK_FALSE;
         samplerInfo.compareEnable = VK_FALSE;
         samplerInfo.compareOp = VK_COMPARE_OP_ALWAYS;
         samplerInfo.mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR;
-        samplerInfo.minLod = 0;
+        samplerInfo.minLod = 0.0f;
         samplerInfo.maxLod = static_cast<float>(mipLevels);
-        samplerInfo.mipLodBias = 0;
+        samplerInfo.mipLodBias = 0.0f;
 
         if (vkCreateSampler(device, &samplerInfo, nullptr, &textureSampler) != VK_SUCCESS) {
             throw std::runtime_error("failed to create texture sampler!");

--- a/code/29_multisampling.cpp
+++ b/code/29_multisampling.cpp
@@ -1002,15 +1002,15 @@ VkSampleCountFlagBits getMaxUsableSampleCount() {
         samplerInfo.addressModeV = VK_SAMPLER_ADDRESS_MODE_REPEAT;
         samplerInfo.addressModeW = VK_SAMPLER_ADDRESS_MODE_REPEAT;
         samplerInfo.anisotropyEnable = VK_TRUE;
-        samplerInfo.maxAnisotropy = 16;
+        samplerInfo.maxAnisotropy = 16.0f;
         samplerInfo.borderColor = VK_BORDER_COLOR_INT_OPAQUE_BLACK;
         samplerInfo.unnormalizedCoordinates = VK_FALSE;
         samplerInfo.compareEnable = VK_FALSE;
         samplerInfo.compareOp = VK_COMPARE_OP_ALWAYS;
         samplerInfo.mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR;
-        samplerInfo.minLod = 0;
+        samplerInfo.minLod = 0.0f;
         samplerInfo.maxLod = static_cast<float>(mipLevels);
-        samplerInfo.mipLodBias = 0;
+        samplerInfo.mipLodBias = 0.0f;
 
         if (vkCreateSampler(device, &samplerInfo, nullptr, &textureSampler) != VK_SUCCESS) {
             throw std::runtime_error("failed to create texture sampler!");

--- a/en/06_Texture_mapping/01_Image_view_and_sampler.md
+++ b/en/06_Texture_mapping/01_Image_view_and_sampler.md
@@ -218,7 +218,7 @@ floors and walls.
 
 ```c++
 samplerInfo.anisotropyEnable = VK_TRUE;
-samplerInfo.maxAnisotropy = 16;
+samplerInfo.maxAnisotropy = 16.0f;
 ```
 
 These two fields specify if anisotropic filtering should be used. There is no
@@ -346,7 +346,7 @@ possible to simply not use it by conditionally setting:
 
 ```c++
 samplerInfo.anisotropyEnable = VK_FALSE;
-samplerInfo.maxAnisotropy = 1;
+samplerInfo.maxAnisotropy = 1.0f;
 ```
 
 In the next chapter we will expose the image and sampler objects to the shaders

--- a/en/09_Generating_Mipmaps.md
+++ b/en/09_Generating_Mipmaps.md
@@ -314,14 +314,14 @@ To see the results of this chapter, we need to choose values for our `textureSam
 void createTextureSampler() {
     ...
     samplerInfo.mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR;
-    samplerInfo.minLod = 0; // Optional
+    samplerInfo.minLod = 0.0f; // Optional
     samplerInfo.maxLod = static_cast<float>(mipLevels);
-    samplerInfo.mipLodBias = 0; // Optional
+    samplerInfo.mipLodBias = 0.0f; // Optional
     ...
 }
 ```
 
-To allow the full range of mip levels to be used, we set `minLod` to 0, and `maxLod` to the number of mip levels. We have no reason to change the `lod` value , so we set `mipLodBias` to 0.
+To allow the full range of mip levels to be used, we set `minLod` to 0.0f, and `maxLod` to the number of mip levels. We have no reason to change the `lod` value , so we set `mipLodBias` to 0.0f.
 
 Now run your program and you should see the following:
 

--- a/fr/06_Texture_mapping/01_Vue_sur_image_et_sampler.md
+++ b/fr/06_Texture_mapping/01_Vue_sur_image_et_sampler.md
@@ -200,7 +200,7 @@ même carré à la pipeline, pour dessiner un pavage au sol par exemple.
 
 ```c++
 samplerInfo.anisotropyEnable = VK_TRUE;
-samplerInfo.maxAnisotropy = 16;
+samplerInfo.maxAnisotropy = 16.0f;
 ```
 
 Ces deux membres paramètrent l'utilisation de l'anistropic filtering. Il n'y a pas vraiment de raison de ne pas
@@ -317,7 +317,7 @@ conditionnellement activer ou pas l'anistropic filtering :
 
 ```c++
 samplerInfo.anisotropyEnable = VK_FALSE;
-samplerInfo.maxAnisotropy = 1;
+samplerInfo.maxAnisotropy = 1.0f;
 ```
 
 Dans le prochain chapitre nous exposerons l'image et le sampler au fragment shader pour qu'il puisse utiliser la

--- a/fr/09_Générer_des_mipmaps.md
+++ b/fr/09_Générer_des_mipmaps.md
@@ -372,15 +372,15 @@ Pour voir les résultats de ce chapitre, nous devons choisir les valeurs pour `t
 void createTextureSampler() {
     ...
     samplerInfo.mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR;
-    samplerInfo.minLod = 0;
+    samplerInfo.minLod = 0.0f;
     samplerInfo.maxLod = static_cast<float>(mipLevels);
-    samplerInfo.mipLodBias = 0; // Optionel
+    samplerInfo.mipLodBias = 0.0f; // Optionel
     ...
 }
 ```
 
-Pour utiliser la totalité des niveaux de mipmaps, nous mettons `minLod` à `0` et `maxLod` au nombre de niveaux de
-mipmaps. Nous n'avons aucune raison d'altérer `lod` avec `mipLodBias`, alors nous pouvons le mettre à `0`.
+Pour utiliser la totalité des niveaux de mipmaps, nous mettons `minLod` à `0.0f` et `maxLod` au nombre de niveaux de
+mipmaps. Nous n'avons aucune raison d'altérer `lod` avec `mipLodBias`, alors nous pouvons le mettre à `0.0f`.
 
 Lancez votre programme et vous devriez voir ceci :
 


### PR DESCRIPTION
I've noticed that four members of the `VkSamplerCreateInfo` struct are floats, but assigned integer values in various places. Although implicit type conversion will be performed at compile time, I think this should be changed because of two reasons:

1. Assigning integer values to the members may lead to the assumption that the members itself are of an integer type. This wrong assumption may lead to trouble (missing casts, invalid bitwise operations).
2. The member types are an important semantic clue (f.i. one could assume that `maxAnisotropy` might represent a number of samples, whereas this idea does not seem probable when looking at a float assignment). 

The definition of `VkSamplerCreateInfo` as of Vulkan 1.2 can be found [here](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/html/vkspec.html#VkSamplerCreateInfo). 