### PR TITLE
fix typo in 01_Swap_chain.md

### DIFF
--- a/en/03_Drawing_a_triangle/01_Presentation/01_Swap_chain.md
+++ b/en/03_Drawing_a_triangle/01_Presentation/01_Swap_chain.md
@@ -452,7 +452,7 @@ on the presentation queue. There are two ways to handle images that are
 accessed from multiple queues:
 
 * `VK_SHARING_MODE_EXCLUSIVE`: An image is owned by one queue family at a time
-and ownership must be explicitly transfered before using it in another queue
+and ownership must be explicitly transferred before using it in another queue
 family. This option offers the best performance.
 * `VK_SHARING_MODE_CONCURRENT`: Images can be used across multiple queue
 families without explicit ownership transfers.


### PR DESCRIPTION
fix just a typo on the word "transfered" that should be spelled transferred