### PR TITLE
Add remark regarding queue type for vkCmdBlitImage

### DIFF
--- a/en/09_Generating_Mipmaps.md
+++ b/en/09_Generating_Mipmaps.md
@@ -177,6 +177,8 @@ vkCmdBlitImage(commandBuffer,
 
 Now, we record the blit command. Note that `textureImage` is used for both the `srcImage` and `dstImage` parameter. This is because we're blitting between different levels of the same image. The source mip level was just transitioned to `VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL` and the destination level is still in `VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL` from `createTextureImage`.
 
+Beware if you are using a dedicated transfer queue (as suggested in [Vertex buffers](!en/Vertex_buffers/Staging_buffer)): `vkCmdBlitImage` must be submitted to a queue with graphics capability.
+
 The last parameter allows us to specify a `VkFilter` to use in the blit. We have the same filtering options here that we had when making the `VkSampler`. We use the `VK_FILTER_LINEAR` to enable interpolation.
 
 ```c++


### PR DESCRIPTION
I'm not sure if this fits stylistically. :)

All my queues have graphics capability, so I can't check what the validation layer may have to say about using a transfer-only queue.