### PR TITLE
Fix else branch of chooseSwapExtent for HDPI/retina displays

### DIFF
--- a/code/06_swap_chain_creation.cpp
+++ b/code/06_swap_chain_creation.cpp
@@ -334,7 +334,13 @@ private:
         if (capabilities.currentExtent.width != UINT32_MAX) {
             return capabilities.currentExtent;
         } else {
-            VkExtent2D actualExtent = {WIDTH, HEIGHT};
+            int width, height;
+            glfwGetFramebufferSize(window, &width, &height);
+
+            VkExtent2D actualExtent = {
+                static_cast<uint32_t>(width),
+                static_cast<uint32_t>(height)
+            };
 
             actualExtent.width = std::max(capabilities.minImageExtent.width, std::min(capabilities.maxImageExtent.width, actualExtent.width));
             actualExtent.height = std::max(capabilities.minImageExtent.height, std::min(capabilities.maxImageExtent.height, actualExtent.height));

--- a/code/07_image_views.cpp
+++ b/code/07_image_views.cpp
@@ -365,7 +365,13 @@ private:
         if (capabilities.currentExtent.width != UINT32_MAX) {
             return capabilities.currentExtent;
         } else {
-            VkExtent2D actualExtent = {WIDTH, HEIGHT};
+            int width, height;
+            glfwGetFramebufferSize(window, &width, &height);
+
+            VkExtent2D actualExtent = {
+                static_cast<uint32_t>(width),
+                static_cast<uint32_t>(height)
+            };
 
             actualExtent.width = std::max(capabilities.minImageExtent.width, std::min(capabilities.maxImageExtent.width, actualExtent.width));
             actualExtent.height = std::max(capabilities.minImageExtent.height, std::min(capabilities.maxImageExtent.height, actualExtent.height));

--- a/code/08_graphics_pipeline.cpp
+++ b/code/08_graphics_pipeline.cpp
@@ -370,7 +370,13 @@ private:
         if (capabilities.currentExtent.width != UINT32_MAX) {
             return capabilities.currentExtent;
         } else {
-            VkExtent2D actualExtent = {WIDTH, HEIGHT};
+            int width, height;
+            glfwGetFramebufferSize(window, &width, &height);
+
+            VkExtent2D actualExtent = {
+                static_cast<uint32_t>(width),
+                static_cast<uint32_t>(height)
+            };
 
             actualExtent.width = std::max(capabilities.minImageExtent.width, std::min(capabilities.maxImageExtent.width, actualExtent.width));
             actualExtent.height = std::max(capabilities.minImageExtent.height, std::min(capabilities.maxImageExtent.height, actualExtent.height));

--- a/code/09_shader_modules.cpp
+++ b/code/09_shader_modules.cpp
@@ -406,7 +406,13 @@ private:
         if (capabilities.currentExtent.width != UINT32_MAX) {
             return capabilities.currentExtent;
         } else {
-            VkExtent2D actualExtent = {WIDTH, HEIGHT};
+            int width, height;
+            glfwGetFramebufferSize(window, &width, &height);
+
+            VkExtent2D actualExtent = {
+                static_cast<uint32_t>(width),
+                static_cast<uint32_t>(height)
+            };
 
             actualExtent.width = std::max(capabilities.minImageExtent.width, std::min(capabilities.maxImageExtent.width, actualExtent.width));
             actualExtent.height = std::max(capabilities.minImageExtent.height, std::min(capabilities.maxImageExtent.height, actualExtent.height));

--- a/code/10_fixed_functions.cpp
+++ b/code/10_fixed_functions.cpp
@@ -478,7 +478,13 @@ private:
         if (capabilities.currentExtent.width != UINT32_MAX) {
             return capabilities.currentExtent;
         } else {
-            VkExtent2D actualExtent = {WIDTH, HEIGHT};
+            int width, height;
+            glfwGetFramebufferSize(window, &width, &height);
+
+            VkExtent2D actualExtent = {
+                static_cast<uint32_t>(width),
+                static_cast<uint32_t>(height)
+            };
 
             actualExtent.width = std::max(capabilities.minImageExtent.width, std::min(capabilities.maxImageExtent.width, actualExtent.width));
             actualExtent.height = std::max(capabilities.minImageExtent.height, std::min(capabilities.maxImageExtent.height, actualExtent.height));

--- a/code/11_render_passes.cpp
+++ b/code/11_render_passes.cpp
@@ -513,7 +513,13 @@ private:
         if (capabilities.currentExtent.width != UINT32_MAX) {
             return capabilities.currentExtent;
         } else {
-            VkExtent2D actualExtent = {WIDTH, HEIGHT};
+            int width, height;
+            glfwGetFramebufferSize(window, &width, &height);
+
+            VkExtent2D actualExtent = {
+                static_cast<uint32_t>(width),
+                static_cast<uint32_t>(height)
+            };
 
             actualExtent.width = std::max(capabilities.minImageExtent.width, std::min(capabilities.maxImageExtent.width, actualExtent.width));
             actualExtent.height = std::max(capabilities.minImageExtent.height, std::min(capabilities.maxImageExtent.height, actualExtent.height));

--- a/code/12_graphics_pipeline_complete.cpp
+++ b/code/12_graphics_pipeline_complete.cpp
@@ -534,7 +534,13 @@ private:
         if (capabilities.currentExtent.width != UINT32_MAX) {
             return capabilities.currentExtent;
         } else {
-            VkExtent2D actualExtent = {WIDTH, HEIGHT};
+            int width, height;
+            glfwGetFramebufferSize(window, &width, &height);
+
+            VkExtent2D actualExtent = {
+                static_cast<uint32_t>(width),
+                static_cast<uint32_t>(height)
+            };
 
             actualExtent.width = std::max(capabilities.minImageExtent.width, std::min(capabilities.maxImageExtent.width, actualExtent.width));
             actualExtent.height = std::max(capabilities.minImageExtent.height, std::min(capabilities.maxImageExtent.height, actualExtent.height));

--- a/code/13_framebuffers.cpp
+++ b/code/13_framebuffers.cpp
@@ -563,7 +563,13 @@ private:
         if (capabilities.currentExtent.width != UINT32_MAX) {
             return capabilities.currentExtent;
         } else {
-            VkExtent2D actualExtent = {WIDTH, HEIGHT};
+            int width, height;
+            glfwGetFramebufferSize(window, &width, &height);
+
+            VkExtent2D actualExtent = {
+                static_cast<uint32_t>(width),
+                static_cast<uint32_t>(height)
+            };
 
             actualExtent.width = std::max(capabilities.minImageExtent.width, std::min(capabilities.maxImageExtent.width, actualExtent.width));
             actualExtent.height = std::max(capabilities.minImageExtent.height, std::min(capabilities.maxImageExtent.height, actualExtent.height));

--- a/code/14_command_buffers.cpp
+++ b/code/14_command_buffers.cpp
@@ -628,7 +628,13 @@ private:
         if (capabilities.currentExtent.width != UINT32_MAX) {
             return capabilities.currentExtent;
         } else {
-            VkExtent2D actualExtent = {WIDTH, HEIGHT};
+            int width, height;
+            glfwGetFramebufferSize(window, &width, &height);
+
+            VkExtent2D actualExtent = {
+                static_cast<uint32_t>(width),
+                static_cast<uint32_t>(height)
+            };
 
             actualExtent.width = std::max(capabilities.minImageExtent.width, std::min(capabilities.maxImageExtent.width, actualExtent.width));
             actualExtent.height = std::max(capabilities.minImageExtent.height, std::min(capabilities.maxImageExtent.height, actualExtent.height));

--- a/code/15_hello_triangle.cpp
+++ b/code/15_hello_triangle.cpp
@@ -728,7 +728,13 @@ private:
         if (capabilities.currentExtent.width != UINT32_MAX) {
             return capabilities.currentExtent;
         } else {
-            VkExtent2D actualExtent = {WIDTH, HEIGHT};
+            int width, height;
+            glfwGetFramebufferSize(window, &width, &height);
+
+            VkExtent2D actualExtent = {
+                static_cast<uint32_t>(width),
+                static_cast<uint32_t>(height)
+            };
 
             actualExtent.width = std::max(capabilities.minImageExtent.width, std::min(capabilities.maxImageExtent.width, actualExtent.width));
             actualExtent.height = std::max(capabilities.minImageExtent.height, std::min(capabilities.maxImageExtent.height, actualExtent.height));

--- a/en/03_Drawing_a_triangle/04_Swap_chain_recreation.md
+++ b/en/03_Drawing_a_triangle/04_Swap_chain_recreation.md
@@ -117,7 +117,7 @@ allocate the new command buffers.
 Note that in `chooseSwapExtent` we already query the new window resolution to
 make sure that the swap chain images have the (new) right size, so there's no
 need to modify `chooseSwapExtent` (remember that we already had to use
-`glfwGetFramebufferSize` get the resolution of the surface in pixel when
+`glfwGetFramebufferSize` get the resolution of the surface in pixels when
 creating the swap chain).
 
 That's all it takes to recreate the swap chain! However, the disadvantage of

--- a/en/03_Drawing_a_triangle/04_Swap_chain_recreation.md
+++ b/en/03_Drawing_a_triangle/04_Swap_chain_recreation.md
@@ -114,25 +114,11 @@ Instead I've opted to clean up the existing command buffers with the
 `vkFreeCommandBuffers` function. This way we can reuse the existing pool to
 allocate the new command buffers.
 
-To handle window resizes properly, we also need to query the current size of the framebuffer to make sure that the swap chain images have the (new) right size. To do that change the `chooseSwapExtent` function to take the actual size into account:
-
-```c++
-VkExtent2D chooseSwapExtent(const VkSurfaceCapabilitiesKHR& capabilities) {
-    if (capabilities.currentExtent.width != UINT32_MAX) {
-        return capabilities.currentExtent;
-    } else {
-        int width, height;
-        glfwGetFramebufferSize(window, &width, &height);
-
-        VkExtent2D actualExtent = {
-            static_cast<uint32_t>(width),
-            static_cast<uint32_t>(height)
-        };
-
-        ...
-    }
-}
-```
+Note that in `chooseSwapExtent` we already query the new window resolution to
+make sure that the swap chain images have the (new) right size, so there's no
+need to modify `chooseSwapExtent` (remember that we already had to use
+`glfwGetFramebufferSize` get the resolution of the surface in pixel when
+creating the swap chain).
 
 That's all it takes to recreate the swap chain! However, the disadvantage of
 this approach is that we need to stop all rendering before creating the new swap


### PR DESCRIPTION
When using an HDPI display, using the window size `{WIDTH, HEIGHT}` to determine swapchain image size is incorrect. See the following links:

* https://www.glfw.org/docs/latest/window.html#window_size
* https://www.glfw.org/docs/latest/window.html#window_fbsize
* https://www.glfw.org/faq.html#43---why-is-my-output-in-the-lower-left-corner-of-the-window

Short version: The window size in GLFW is specified in screen coordinates, but Vulkan requires the swapchain image extent to be specified in pixel. On HDPI displays, these are not the same thing.

Instead, the framebuffer size is now used to determine the swapchain extent. Using the implementation of `chooseSwapExtent` from `16_swap_chain_recreation.cpp` seemed appropriate. Beyond "Swap chain recreation" no changes are necessary.

I'm a little bit suprised that this hasn't been an issue for anyone. I'm using macOS, and my app doesn't enter the `else` branch, so I don't experience any problems either (Vulkan automatically suggests doubled width and height). The specification doesn't seem to say _when_ `width == UINT32_MAX` occurs.