### PR TITLE
Add `spirv-tools` package to 02_Development_environment.md

### DIFF
--- a/en/02_Development_environment.md
+++ b/en/02_Development_environment.md
@@ -204,7 +204,7 @@ The most important components you'll need for developing Vulkan applications on 
 
 * `sudo apt install vulkan-tools`: Command-line utilities, most importantly `vulkaninfo` and `vkcube`. Run these to confirm your machine supports Vulkan.
 * `sudo apt install libvulkan-dev`: Installs Vulkan loader. The loader looks up the functions in the driver at runtime, similarly to GLEW for OpenGL - if you're familiar with that.
-* `sudo apt install vulkan-validationlayers-dev`: Installs the standard validation layers. These are crucial when debugging Vulkan applications, and we'll discuss them in the upcoming chapter.
+* `sudo apt install vulkan-validationlayers-dev spirv-tools`: Installs the standard validation layers and required SPIR-V tools. These are crucial when debugging Vulkan applications, and we'll discuss them in the upcoming chapter.
 
 If installation was successful, you should be all set with the Vulkan portion. Remember to run
  `vkcube` and ensure you see the following pop up in a window:


### PR DESCRIPTION
When doing the [validation layers tutorial](https://vulkan-tutorial.com/Drawing_a_triangle/Setup/Validation_layers), compiling and running the example produced the following error message:
```                                                                              
validation layer: libSPIRV-Tools-opt.so: cannot open shared object file: No such file or directory  
```
and no other validation layer output. After some Googling, I discovered that installing `spirv-tools` fixes the above error message, and causes the expected validation layer messages to appear:
```
VUID-VkDebugUtilsMessengerCreateInfoEXT-flags-zerobitmask(ERROR / SPEC): msgNum: 0 - vkCreateDebugUtilsMessengerEXT: parameter pCreateInfo->flags must be 0. The Vulkan spec states: flags must be 0 (https://www.khronos.org/registry/vulkan/specs/1.1-extensions/html/vkspec.html#VUID-VkDebugUtilsMessengerCreateInfoEXT-flags-zerobitmask)
    Objects: 1
        [0] 0, type: 0, name: NULL
validation layer: OBJ ERROR : For VkInstance 0x563c653c9200[], VkDebugUtilsMessengerEXT 0x10000000001[] has not been destroyed. The Vulkan spec states: All child objects created using instance must have been destroyed prior to destroying instance (https://www.khronos.org/registry/vulkan/specs/1.1-extensions/html/vkspec.html#VUID-vkDestroyInstance-instance-00629)
validation layer: OBJ ERROR : For VkInstance 0x563c653c9200[], VkDebugUtilsMessengerEXT 0x10000000001[] has not been destroyed. The Vulkan spec states: All child objects created using instance must have been destroyed prior to destroying instance (https://www.khronos.org/registry/vulkan/specs/1.1-extensions/html/vkspec.html#VUID-vkDestroyInstance-instance-00629)
```

So this should be added to the Linux development environment setup instructions. 

## System info
(let me know if additional details are required)

Ubuntu 20.04.1 LTS, 64-bit
```
└─ $ ▶ uname -a 
Linux considerable-shouting 5.4.0-53-generic #59-Ubuntu SMP Wed Oct 21 09:38:44 UTC 2020 x86_64 x86_64 x86_64 GNU/Linux

└─ $ ▶ apt list --installed | grep vulkan
libvulkan-dev/focal,now 1.2.131.2-1 amd64 [installed]
libvulkan1/focal,now 1.2.131.2-1 amd64 [installed,automatic]
mesa-vulkan-drivers/focal-updates,now 20.0.8-0ubuntu1~20.04.1 amd64 [installed,automatic]
vulkan-tools/focal,now 1.2.131.1+dfsg1-1 amd64 [installed]
vulkan-validationlayers-dev/focal,now 1.2.131.2-1 amd64 [installed]
vulkan-validationlayers/focal,now 1.2.131.2-1 amd64 [installed,automatic]
```