### PR TITLE
Add extra braces when setting VkClearValue

### DIFF
--- a/code/14_command_buffers.cpp
+++ b/code/14_command_buffers.cpp
@@ -572,7 +572,7 @@ private:
             renderPassInfo.renderArea.offset = {0, 0};
             renderPassInfo.renderArea.extent = swapChainExtent;
 
-            VkClearValue clearColor = {0.0f, 0.0f, 0.0f, 1.0f};
+            VkClearValue clearColor = {{{0.0f, 0.0f, 0.0f, 1.0f}}};
             renderPassInfo.clearValueCount = 1;
             renderPassInfo.pClearValues = &clearColor;
 

--- a/code/15_hello_triangle.cpp
+++ b/code/15_hello_triangle.cpp
@@ -600,7 +600,7 @@ private:
             renderPassInfo.renderArea.offset = {0, 0};
             renderPassInfo.renderArea.extent = swapChainExtent;
 
-            VkClearValue clearColor = {0.0f, 0.0f, 0.0f, 1.0f};
+            VkClearValue clearColor = {{{0.0f, 0.0f, 0.0f, 1.0f}}};
             renderPassInfo.clearValueCount = 1;
             renderPassInfo.pClearValues = &clearColor;
 

--- a/code/16_swap_chain_recreation.cpp
+++ b/code/16_swap_chain_recreation.cpp
@@ -635,7 +635,7 @@ private:
             renderPassInfo.renderArea.offset = {0, 0};
             renderPassInfo.renderArea.extent = swapChainExtent;
 
-            VkClearValue clearColor = {0.0f, 0.0f, 0.0f, 1.0f};
+            VkClearValue clearColor = {{{0.0f, 0.0f, 0.0f, 1.0f}}};
             renderPassInfo.clearValueCount = 1;
             renderPassInfo.pClearValues = &clearColor;
 

--- a/code/17_vertex_input.cpp
+++ b/code/17_vertex_input.cpp
@@ -680,7 +680,7 @@ private:
             renderPassInfo.renderArea.offset = {0, 0};
             renderPassInfo.renderArea.extent = swapChainExtent;
 
-            VkClearValue clearColor = {0.0f, 0.0f, 0.0f, 1.0f};
+            VkClearValue clearColor = {{{0.0f, 0.0f, 0.0f, 1.0f}}};
             renderPassInfo.clearValueCount = 1;
             renderPassInfo.pClearValues = &clearColor;
 

--- a/code/18_vertex_buffer.cpp
+++ b/code/18_vertex_buffer.cpp
@@ -732,7 +732,7 @@ private:
             renderPassInfo.renderArea.offset = {0, 0};
             renderPassInfo.renderArea.extent = swapChainExtent;
 
-            VkClearValue clearColor = {0.0f, 0.0f, 0.0f, 1.0f};
+            VkClearValue clearColor = {{{0.0f, 0.0f, 0.0f, 1.0f}}};
             renderPassInfo.clearValueCount = 1;
             renderPassInfo.pClearValues = &clearColor;
 

--- a/code/19_staging_buffer.cpp
+++ b/code/19_staging_buffer.cpp
@@ -780,7 +780,7 @@ private:
             renderPassInfo.renderArea.offset = {0, 0};
             renderPassInfo.renderArea.extent = swapChainExtent;
 
-            VkClearValue clearColor = {0.0f, 0.0f, 0.0f, 1.0f};
+            VkClearValue clearColor = {{{0.0f, 0.0f, 0.0f, 1.0f}}};
             renderPassInfo.clearValueCount = 1;
             renderPassInfo.pClearValues = &clearColor;
 

--- a/code/20_index_buffer.cpp
+++ b/code/20_index_buffer.cpp
@@ -811,7 +811,7 @@ private:
             renderPassInfo.renderArea.offset = {0, 0};
             renderPassInfo.renderArea.extent = swapChainExtent;
 
-            VkClearValue clearColor = {0.0f, 0.0f, 0.0f, 1.0f};
+            VkClearValue clearColor = {{{0.0f, 0.0f, 0.0f, 1.0f}}};
             renderPassInfo.clearValueCount = 1;
             renderPassInfo.pClearValues = &clearColor;
 

--- a/code/21_descriptor_layout.cpp
+++ b/code/21_descriptor_layout.cpp
@@ -863,7 +863,7 @@ private:
             renderPassInfo.renderArea.offset = {0, 0};
             renderPassInfo.renderArea.extent = swapChainExtent;
 
-            VkClearValue clearColor = {0.0f, 0.0f, 0.0f, 1.0f};
+            VkClearValue clearColor = {{{0.0f, 0.0f, 0.0f, 1.0f}}};
             renderPassInfo.clearValueCount = 1;
             renderPassInfo.pClearValues = &clearColor;
 

--- a/code/22_descriptor_sets.cpp
+++ b/code/22_descriptor_sets.cpp
@@ -920,7 +920,7 @@ private:
             renderPassInfo.renderArea.offset = {0, 0};
             renderPassInfo.renderArea.extent = swapChainExtent;
 
-            VkClearValue clearColor = {0.0f, 0.0f, 0.0f, 1.0f};
+            VkClearValue clearColor = {{{0.0f, 0.0f, 0.0f, 1.0f}}};
             renderPassInfo.clearValueCount = 1;
             renderPassInfo.pClearValues = &clearColor;
 

--- a/code/23_texture_image.cpp
+++ b/code/23_texture_image.cpp
@@ -1075,7 +1075,7 @@ private:
             renderPassInfo.renderArea.offset = {0, 0};
             renderPassInfo.renderArea.extent = swapChainExtent;
 
-            VkClearValue clearColor = {0.0f, 0.0f, 0.0f, 1.0f};
+            VkClearValue clearColor = {{{0.0f, 0.0f, 0.0f, 1.0f}}};
             renderPassInfo.clearValueCount = 1;
             renderPassInfo.pClearValues = &clearColor;
 

--- a/code/24_sampler.cpp
+++ b/code/24_sampler.cpp
@@ -1114,7 +1114,7 @@ private:
             renderPassInfo.renderArea.offset = {0, 0};
             renderPassInfo.renderArea.extent = swapChainExtent;
 
-            VkClearValue clearColor = {0.0f, 0.0f, 0.0f, 1.0f};
+            VkClearValue clearColor = {{{0.0f, 0.0f, 0.0f, 1.0f}}};
             renderPassInfo.clearValueCount = 1;
             renderPassInfo.pClearValues = &clearColor;
 

--- a/code/25_texture_mapping.cpp
+++ b/code/25_texture_mapping.cpp
@@ -1144,7 +1144,7 @@ private:
             renderPassInfo.renderArea.offset = {0, 0};
             renderPassInfo.renderArea.extent = swapChainExtent;
 
-            VkClearValue clearColor = {0.0f, 0.0f, 0.0f, 1.0f};
+            VkClearValue clearColor = {{{0.0f, 0.0f, 0.0f, 1.0f}}};
             renderPassInfo.clearValueCount = 1;
             renderPassInfo.pClearValues = &clearColor;
 

--- a/code/26_depth_buffering.cpp
+++ b/code/26_depth_buffering.cpp
@@ -1222,7 +1222,7 @@ private:
             renderPassInfo.renderArea.extent = swapChainExtent;
 
             std::array<VkClearValue, 2> clearValues{};
-            clearValues[0].color = {0.0f, 0.0f, 0.0f, 1.0f};
+            clearValues[0].color = {{0.0f, 0.0f, 0.0f, 1.0f}};
             clearValues[1].depthStencil = {1.0f, 0};
 
             renderPassInfo.clearValueCount = static_cast<uint32_t>(clearValues.size());

--- a/code/27_model_loading.cpp
+++ b/code/27_model_loading.cpp
@@ -1268,7 +1268,7 @@ private:
             renderPassInfo.renderArea.extent = swapChainExtent;
 
             std::array<VkClearValue, 2> clearValues{};
-            clearValues[0].color = {0.0f, 0.0f, 0.0f, 1.0f};
+            clearValues[0].color = {{0.0f, 0.0f, 0.0f, 1.0f}};
             clearValues[1].depthStencil = {1.0f, 0};
 
             renderPassInfo.clearValueCount = static_cast<uint32_t>(clearValues.size());

--- a/code/28_mipmapping.cpp
+++ b/code/28_mipmapping.cpp
@@ -1362,7 +1362,7 @@ private:
             renderPassInfo.renderArea.extent = swapChainExtent;
 
             std::array<VkClearValue, 2> clearValues{};
-            clearValues[0].color = {0.0f, 0.0f, 0.0f, 1.0f};
+            clearValues[0].color = {{0.0f, 0.0f, 0.0f, 1.0f}};
             clearValues[1].depthStencil = {1.0f, 0};
 
             renderPassInfo.clearValueCount = static_cast<uint32_t>(clearValues.size());

--- a/code/29_multisampling.cpp
+++ b/code/29_multisampling.cpp
@@ -1412,7 +1412,7 @@ VkSampleCountFlagBits getMaxUsableSampleCount() {
             renderPassInfo.renderArea.extent = swapChainExtent;
 
             std::array<VkClearValue, 2> clearValues{};
-            clearValues[0].color = {0.0f, 0.0f, 0.0f, 1.0f};
+            clearValues[0].color = {{0.0f, 0.0f, 0.0f, 1.0f}};
             clearValues[1].depthStencil = {1.0f, 0};
 
             renderPassInfo.clearValueCount = static_cast<uint32_t>(clearValues.size());

--- a/en/03_Drawing_a_triangle/03_Drawing/01_Command_buffers.md
+++ b/en/03_Drawing_a_triangle/03_Drawing/01_Command_buffers.md
@@ -220,7 +220,7 @@ region will have undefined values. It should match the size of the attachments
 for best performance.
 
 ```c++
-VkClearValue clearColor = {0.0f, 0.0f, 0.0f, 1.0f};
+VkClearValue clearColor = {{{0.0f, 0.0f, 0.0f, 1.0f}}};
 renderPassInfo.clearValueCount = 1;
 renderPassInfo.pClearValues = &clearColor;
 ```

--- a/en/07_Depth_buffering.md
+++ b/en/07_Depth_buffering.md
@@ -478,7 +478,7 @@ create an array of `VkClearValue` structs:
 
 ```c++
 std::array<VkClearValue, 2> clearValues{};
-clearValues[0].color = {0.0f, 0.0f, 0.0f, 1.0f};
+clearValues[0].color = {{0.0f, 0.0f, 0.0f, 1.0f}};
 clearValues[1].depthStencil = {1.0f, 0};
 
 renderPassInfo.clearValueCount = static_cast<uint32_t>(clearValues.size());

--- a/fr/03_Dessiner_un_triangle/03_Effectuer_le_rendu/01_Command_buffers.md
+++ b/fr/03_Dessiner_un_triangle/03_Effectuer_le_rendu/01_Command_buffers.md
@@ -206,7 +206,7 @@ chargements et stockages shaders se produiront. Les pixels hors de cette région
 doit correspondre à la taille des attachements pour avoir une performance optimale.
 
 ```c++
-VkClearValue clearColor = {0.0f, 0.0f, 0.0f, 1.0f};
+VkClearValue clearColor = {{{0.0f, 0.0f, 0.0f, 1.0f}}};
 renderPassInfo.clearValueCount = 1;
 renderPassInfo.pClearValues = &clearColor;
 ```

--- a/fr/07_Buffer_de_profondeur.md
+++ b/fr/07_Buffer_de_profondeur.md
@@ -435,7 +435,7 @@ suppression. Allez à `createCommandBuffers` et créez un tableau de `VkClearVal
 
 ```c++
 std::array<VkClearValue, 2> clearValues{};
-clearValues[0].color = {0.0f, 0.0f, 0.0f, 1.0f};
+clearValues[0].color = {{0.0f, 0.0f, 0.0f, 1.0f}};
 clearValues[1].depthStencil = {1.0f, 0};
 
 renderPassInfo.clearValueCount = static_cast<uint32_t>(clearValues.size());


### PR DESCRIPTION
`clang++ -Wall` emits the warning "suggest braces around initialization of subobject [-Wmissing-braces]" with code like
```cpp
VkClearValue clearColor = {0.0f, 0.0f, 0.0f, 1.0f};
```

Since this is trying to fill out `clearColor.color.float32`, 3 braces are needed like
```cpp
VkClearValue clearColor = {{{0.0f, 0.0f, 0.0f, 1.0f}}};
```
to avoid the warning.