### PR TITLE
Update link to Ray Tracing book

### DIFF
--- a/en/00_Introduction.md
+++ b/en/00_Introduction.md
@@ -41,7 +41,7 @@ does require you to know the basics of 3D computer graphics. It will not explain
 the math behind perspective projection, for example. See [this online book](https://paroj.github.io/gltut/)
 for a great introduction of computer graphics concepts. Some other great computer graphics resources are:
 
-* [Ray tracing in one weekend](https://github.com/petershirley/raytracinginoneweekend)
+* [Ray tracing in one weekend](https://github.com/RayTracing/raytracing.github.io)
 * [Physically Based Rendering book](http://www.pbr-book.org/)
 * Vulkan being used in a real engine in the open-source [Quake](https://github.com/Novum/vkQuake) and [DOOM 3](https://github.com/DustinHLand/vkDOOM3)
 


### PR DESCRIPTION
It looks like the repo https://github.com/RayTracing/InOneWeekend now points to https://github.com/RayTracing/raytracing.github.io . Updated the link to reflect this.