### PR TITLE
Mention std::clamp in explanatory comment instead of min/max

### DIFF
--- a/en/03_Drawing_a_triangle/01_Presentation/01_Swap_chain.md
+++ b/en/03_Drawing_a_triangle/01_Presentation/01_Swap_chain.md
@@ -339,7 +339,7 @@ matching it against the minimum and maximum image extent.
 
 ```c++
 #include <cstdint> // Necessary for UINT32_MAX
-#include <algorithm> // Necessary for std::min/std::max
+#include <algorithm> // Necessary for std::clamp
 
 ...
 

--- a/fr/03_Dessiner_un_triangle/01_Présentation/01_Swap_chain.md
+++ b/fr/03_Dessiner_un_triangle/01_Présentation/01_Swap_chain.md
@@ -297,7 +297,7 @@ fenêtre, dans les bornes de `minImageExtent` et `maxImageExtent`.
 
 ```c++
 #include <cstdint> // UINT32_MAX
-#include <algorithm> // std::min/std::max
+#include <algorithm> // std::clamp
 
 ...
 


### PR DESCRIPTION
I suspect the example code used `std::min` and `std::max` and was later changed to `std::clamp`.