### PR TITLE
Use std::numeric_limits<uint32_t>::max()

### DIFF
--- a/en/03_Drawing_a_triangle/01_Presentation/01_Swap_chain.md
+++ b/en/03_Drawing_a_triangle/01_Presentation/01_Swap_chain.md
@@ -338,13 +338,14 @@ for us, we can't just use the original `{WIDTH, HEIGHT}`. Instead, we must use
 matching it against the minimum and maximum image extent.
 
 ```c++
-#include <cstdint> // Necessary for UINT32_MAX
+#include <cstdint> // Necessary for uint32_t
+#include <limits> // Necessary for std::numeric_limits
 #include <algorithm> // Necessary for std::clamp
 
 ...
 
 VkExtent2D chooseSwapExtent(const VkSurfaceCapabilitiesKHR& capabilities) {
-    if (capabilities.currentExtent.width != UINT32_MAX) {
+    if (capabilities.currentExtent.width != std::numeric_limits<uint32_t>::max()) {
         return capabilities.currentExtent;
     } else {
         int width, height;


### PR DESCRIPTION
Proposed change to use C++ typed limits. If this is acceptable, probably should be applied to the French version and the code examples, too.