### PR TITLE
enable best practices validation

### DIFF
--- a/code/30_multisampling.cpp
+++ b/code/30_multisampling.cpp
@@ -378,8 +378,16 @@ private:
             createInfo.enabledLayerCount = static_cast<uint32_t>(validationLayers.size());
             createInfo.ppEnabledLayerNames = validationLayers.data();
 
+            // enable best practices validation
+            VkValidationFeatureEnableEXT enables[] = { VK_VALIDATION_FEATURE_ENABLE_BEST_PRACTICES_EXT };
+            VkValidationFeaturesEXT features = {};
+            features.sType = VK_STRUCTURE_TYPE_VALIDATION_FEATURES_EXT;
+            features.enabledValidationFeatureCount = 1;
+            features.pEnabledValidationFeatures = enables;
+            createInfo.pNext = &features;
+
             populateDebugMessengerCreateInfo(debugCreateInfo);
-            createInfo.pNext = (VkDebugUtilsMessengerCreateInfoEXT*) &debugCreateInfo;
+            features.pNext = (VkDebugUtilsMessengerCreateInfoEXT*) &debugCreateInfo;
         } else {
             createInfo.enabledLayerCount = 0;
 


### PR DESCRIPTION
There are some best practices validation warnings. Maybe we can fix them together? Here are two that I simply can't fix because I don't know what's causing them:

- Validation Warning: [ UNASSIGNED-BestPractices-pipeline-stage-flags ] Object 0: handle = 0x1ddf07b8550, type = VK_OBJECT_TYPE_DEVICE; | MessageID = 0x48a09f6c | You are using VK_PIPELINE_STAGE_ALL_COMMANDS_BIT when vkCmdPipelineBarrier is called
- Validation Performance Warning: [ UNASSIGNED-BestPractices-vkCreateCommandPool-command-buffer-reset ] Object 0: handle = 0x2a6c31da9d0, type = VK_OBJECT_TYPE_DEVICE; | MessageID = 0x8728e724 | vkCreateCommandPool(): VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT is set. Consider resetting entire pool instead.