### PR TITLE
vkDestroyDescriptorPool added to Descriptor pool and sets

### DIFF
--- a/en/05_Uniform_buffers/01_Descriptor_pool_and_sets.md
+++ b/en/05_Uniform_buffers/01_Descriptor_pool_and_sets.md
@@ -135,6 +135,14 @@ automatically freed when the descriptor pool is destroyed. The call to
 `vkAllocateDescriptorSets` will allocate descriptor sets, each with one uniform
 buffer descriptor.
 
+```c++
+void cleanup() {
+    vkDestroyDescriptorPool(device, descriptorPool, nullptr);
+    
+    vkDestroyDescriptorSetLayout(device, descriptorSetLayout, nullptr);
+}
+```
+
 The descriptor sets have been allocated now, but the descriptors within still need
 to be configured. We'll now add a loop to populate every descriptor:
 

--- a/en/05_Uniform_buffers/01_Descriptor_pool_and_sets.md
+++ b/en/05_Uniform_buffers/01_Descriptor_pool_and_sets.md
@@ -137,9 +137,11 @@ buffer descriptor.
 
 ```c++
 void cleanup() {
+    ...
     vkDestroyDescriptorPool(device, descriptorPool, nullptr);
     
     vkDestroyDescriptorSetLayout(device, descriptorSetLayout, nullptr);
+    ...
 }
 ```
 

--- a/fr/05_Uniform_buffers/01_Descriptor_pool_et_sets.md
+++ b/fr/05_Uniform_buffers/01_Descriptor_pool_et_sets.md
@@ -146,6 +146,16 @@ Il n'est pas nécessaire de détruire les sets de descripteurs explicitement, ca
 destruction de la pool. L'appel à `vkAllocateDescriptorSets` alloue donc tous les sets, chacun possédant un unique
 descripteur d'UBO.
 
+```c++
+void cleanup() {
+    ...
+    vkDestroyDescriptorPool(device, descriptorPool, nullptr);
+    
+    vkDestroyDescriptorSetLayout(device, descriptorSetLayout, nullptr);
+    ...
+}
+```
+
 Nous avons créé les sets mais nous n'avons pas paramétré les descripteurs. Nous allons maintenant créer une boucle pour
 rectifier ce problème :
 


### PR DESCRIPTION
The **vkDestroyDescriptorPool** is missing from the tutorial and vulkan gives a warning for it.
However it is present in the code examples in the github repo: [23_descriptor_sets.cpp](https://github.com/Overv/VulkanTutorial/blob/master/code/23_descriptor_sets.cpp)