### PR TITLE
Remove outdated reference to swapchain

### DIFF
--- a/en/05_Uniform_buffers/00_Descriptor_layout_and_buffer.md
+++ b/en/05_Uniform_buffers/00_Descriptor_layout_and_buffer.md
@@ -273,28 +273,21 @@ void createUniformBuffers() {
 
 We're going to write a separate function that updates the uniform buffer with a
 new transformation every frame, so there will be no `vkMapMemory` here. The
-uniform data will be used for all draw calls, so the buffer containing it should only be destroyed when we stop rendering. Since it also depends on the number of swap chain images, which could change after a recreation, we'll clean it up in `cleanupSwapChain`:
+uniform data will be used for all draw calls, so the buffer containing it should only be destroyed when we stop rendering.
 
 ```c++
-void cleanupSwapChain() {
+void cleanup() {
     ...
 
     for (size_t i = 0; i < MAX_FRAMES_IN_FLIGHT; i++) {
         vkDestroyBuffer(device, uniformBuffers[i], nullptr);
         vkFreeMemory(device, uniformBuffersMemory[i], nullptr);
     }
-}
-```
 
-This means that we also need to recreate it in `recreateSwapChain`:
+    vkDestroyDescriptorSetLayout(device, descriptorSetLayout, nullptr);
 
-```c++
-void recreateSwapChain() {
     ...
 
-    createFramebuffers();
-    createUniformBuffers();
-    createCommandBuffers();
 }
 ```
 

--- a/en/05_Uniform_buffers/01_Descriptor_pool_and_sets.md
+++ b/en/05_Uniform_buffers/01_Descriptor_pool_and_sets.md
@@ -86,13 +86,6 @@ void initVulkan() {
     ...
 }
 
-void recreateSwapChain() {
-    ...
-    createDescriptorPool();
-    createDescriptorSets();
-    ...
-}
-
 ...
 
 void createDescriptorSets() {
@@ -113,7 +106,8 @@ allocInfo.descriptorSetCount = static_cast<uint32_t>(MAX_FRAMES_IN_FLIGHT);
 allocInfo.pSetLayouts = layouts.data();
 ```
 
-In our case we will create one descriptor set for each swap chain image, all with the same layout. Unfortunately we do need all the copies of the layout because the next function expects an array matching the number of sets.
+In our case we will create one descriptor set for each frame in flight, all with the same layout. 
+Unfortunately we do need all the copies of the layout because the next function expects an array matching the number of sets.
 
 Add a class member to hold the descriptor set handles and allocate them with
 `vkAllocateDescriptorSets`:
@@ -219,7 +213,7 @@ as its name implies.
 ## Using descriptor sets
 
 We now need to update the `createCommandBuffers` function to actually bind the
-right descriptor set for each swap chain image to the descriptors in the shader with `vkCmdBindDescriptorSets`. This needs to be done before the `vkCmdDrawIndexed` call:
+right descriptor set for each frame to the descriptors in the shader with `vkCmdBindDescriptorSets`. This needs to be done before the `vkCmdDrawIndexed` call:
 
 ```c++
 vkCmdBindDescriptorSets(commandBuffers[i], VK_PIPELINE_BIND_POINT_GRAPHICS, pipelineLayout, 0, 1, &descriptorSets[i], 0, nullptr);


### PR DESCRIPTION
This commit removes leftover references to the number of swapchain
images in the "Uniform buffers" chapter.

This seems to be an error introduced by the https://github.com/Overv/VulkanTutorial/pull/255 PR.

Just wanted to say a big THANK YOU to everyone who has contributed to this tutorial, it's the only thing making Vulkan approachable!