### PR TITLE
Append new section in 01_Instance.md

### DIFF
--- a/en/03_Drawing_a_triangle/00_Setup/01_Instance.md
+++ b/en/03_Drawing_a_triangle/00_Setup/01_Instance.md
@@ -109,6 +109,37 @@ if (vkCreateInstance(&createInfo, nullptr, &instance) != VK_SUCCESS) {
 
 Now run the program to make sure that the instance is created successfully.
 
+## Encountered VK_ERROR_INCOMPATIBLE_DRIVER:
+If using MacOS with the latest MoltenVK sdk, you may get `VK_ERROR_INCOMPATIBLE_DRIVER`
+returned from `vkCreateInstance`. Accroding to the [Getting Start Notes](https://vulkan.lunarg.com/doc/sdk/1.3.216.0/mac/getting_started.html). Beginning with the 1.3.216 Vulkan SDK, the `VK_KHR_PORTABILITY_subset`
+extension is mandatory.
+
+To get over this error, first add the `VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR` bit
+to `VkInstanceCreateInfo` struct's flags, then add `VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME`
+to instance enabled extension list.
+
+Typically the code could be like this:
+```c++
+...
+
+std::vector<const char*> requiredExtensions;
+
+for(uint32_t i = 0; i < glfwExtensionCount; i++) {
+    requiredExtensions.emplace_back(glfwExtensions[i]);
+}
+
+requiredExtensions.emplace_back(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME)
+
+createInfo.flags |= VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
+
+createInfo.enabledExtensionCount = (uint32_t) requiredExtensions.size();
+createInfo.ppEnabledExtensionNames = requiredExtensions.data();
+
+if (vkCreateInstance(&createInfo, nullptr, &instance) != VK_SUCCESS) {
+    throw std::runtime_error("failed to create instance!");
+}
+```
+
 ## Checking for extension support
 
 If you look at the `vkCreateInstance` documentation then you'll see that one of


### PR DESCRIPTION
Accroding to MoltenVK release notes, the `VK_KHR_PORTABILITY_subset` extension is mandatory. Otherwise `vkCreateInstance` will generate `VK_ERROR_INCOMPATIBLE_DRIVER` error.

So I append a new section in Instance creation chapter to show how to fix this error. I think this is helpful for beganners with MacOS.