### PR TITLE
Fix the recreateSwapChain() function in 07_Depth_buffering.md 

### DIFF
--- a/en/07_Depth_buffering.md
+++ b/en/07_Depth_buffering.md
@@ -573,8 +573,6 @@ void recreateSwapChain() {
 
     createSwapChain();
     createImageViews();
-    createRenderPass();
-    createGraphicsPipeline();
     createDepthResources();
     createFramebuffers();
 }


### PR DESCRIPTION
Fix the recreateSwapChain() function to match the code, which may cause the "Validation Error" if you resize and close window.