### PR TITLE
Change Fedora packages' names

### DIFF
--- a/en/02_Development_environment.md
+++ b/en/02_Development_environment.md
@@ -355,7 +355,7 @@ sudo apt install libxxf86vm-dev libxi-dev
 ```
 or
 ```bash
-sudo dnf install libXi libXxf86vm
+sudo dnf install libXi-devel libXxf86vm-devel
 ```
 or
 ```bash


### PR DESCRIPTION
On Fedora, the packages should be libXi-devel and libXxf86vm-devel, instead of libXi and libXxf86vm. Otherwise, by following the tutorial, we might get errors such as:

```
/usr/bin/ld: cannot find -lXxf86vm
collect2: error: ld returned 1 exit status
make: *** [Makefile:5: VulkanTest] Error 1
```