### PR TITLE
base code: add missing GLFWwindow window var

### DIFF
--- a/en/03_Drawing_a_triangle/00_Setup/00_Base_code.md
+++ b/en/03_Drawing_a_triangle/00_Setup/00_Base_code.md
@@ -174,6 +174,8 @@ window = glfwCreateWindow(WIDTH, HEIGHT, "Vulkan", nullptr, nullptr);
 You should now have a `initWindow` function that looks like this:
 
 ```c++
+GLFWwindow* window;
+
 void initWindow() {
     glfwInit();
 


### PR DESCRIPTION
Declare the window variable with the correct
var type, GLFWwindow.