### PR TITLE
Update 07_Depth_buffering.md

### DIFF
--- a/en/07_Depth_buffering.md
+++ b/en/07_Depth_buffering.md
@@ -421,7 +421,7 @@ renderPassInfo.dependencyCount = 1;
 renderPassInfo.pDependencies = &dependency;
 ```
 
-Next, update the `VkRenderPassCreateInfo` struct to refer to both
+Next, update the `VkSubpassDependency` struct to refer to both
 attachments.
 
 ```c++


### PR DESCRIPTION
Next, update the VkRenderPassCreateInfo struct to refer to both attachments

should be

Next, update the VkSubpassDependency struct to refer to both attachments.


----------------

I checked the source code at the end of the article and indeed VkRenderPassCreateInfo should be VkSubpassDependency