### PR TITLE
Fix incorrect create image view error message

### DIFF
--- a/code/25_sampler.cpp
+++ b/code/25_sampler.cpp
@@ -782,7 +782,7 @@ private:
 
         VkImageView imageView;
         if (vkCreateImageView(device, &viewInfo, nullptr, &imageView) != VK_SUCCESS) {
-            throw std::runtime_error("failed to create texture image view!");
+            throw std::runtime_error("failed to create image view!");
         }
 
         return imageView;

--- a/code/26_texture_mapping.cpp
+++ b/code/26_texture_mapping.cpp
@@ -796,7 +796,7 @@ private:
 
         VkImageView imageView;
         if (vkCreateImageView(device, &viewInfo, nullptr, &imageView) != VK_SUCCESS) {
-            throw std::runtime_error("failed to create texture image view!");
+            throw std::runtime_error("failed to create image view!");
         }
 
         return imageView;

--- a/code/27_depth_buffering.cpp
+++ b/code/27_depth_buffering.cpp
@@ -873,7 +873,7 @@ private:
 
         VkImageView imageView;
         if (vkCreateImageView(device, &viewInfo, nullptr, &imageView) != VK_SUCCESS) {
-            throw std::runtime_error("failed to create texture image view!");
+            throw std::runtime_error("failed to create image view!");
         }
 
         return imageView;

--- a/code/28_model_loading.cpp
+++ b/code/28_model_loading.cpp
@@ -880,7 +880,7 @@ private:
 
         VkImageView imageView;
         if (vkCreateImageView(device, &viewInfo, nullptr, &imageView) != VK_SUCCESS) {
-            throw std::runtime_error("failed to create texture image view!");
+            throw std::runtime_error("failed to create image view!");
         }
 
         return imageView;

--- a/code/29_mipmapping.cpp
+++ b/code/29_mipmapping.cpp
@@ -974,7 +974,7 @@ private:
 
         VkImageView imageView;
         if (vkCreateImageView(device, &viewInfo, nullptr, &imageView) != VK_SUCCESS) {
-            throw std::runtime_error("failed to create texture image view!");
+            throw std::runtime_error("failed to create image view!");
         }
 
         return imageView;

--- a/code/30_multisampling.cpp
+++ b/code/30_multisampling.cpp
@@ -1024,7 +1024,7 @@ private:
 
         VkImageView imageView;
         if (vkCreateImageView(device, &viewInfo, nullptr, &imageView) != VK_SUCCESS) {
-            throw std::runtime_error("failed to create texture image view!");
+            throw std::runtime_error("failed to create image view!");
         }
 
         return imageView;

--- a/en/06_Texture_mapping/01_Image_view_and_sampler.md
+++ b/en/06_Texture_mapping/01_Image_view_and_sampler.md
@@ -76,7 +76,7 @@ VkImageView createImageView(VkImage image, VkFormat format) {
 
     VkImageView imageView;
     if (vkCreateImageView(device, &viewInfo, nullptr, &imageView) != VK_SUCCESS) {
-        throw std::runtime_error("failed to create texture image view!");
+        throw std::runtime_error("failed to create image view!");
     }
 
     return imageView;


### PR DESCRIPTION
The function "createImageView" has a somewhat incorrect error message, saying that it failed to create a texture image view. However, the function is also used by more than simply the texture image view creation process(e.g., the swapchain image view creation process, "createImageViews").

This patch is applied to all subject code files, and the English "06_Texture_mapping/01_Image_view_and_sampler.md" file has also been modified.

The French version of the markdown file remains unchanged due to my lack of knowledge about French, but probably should be changed in the near future to maintain consistency.