### PR TITLE
Fix Vulkan SDK path on Windows

### DIFF
--- a/en/03_Drawing_a_triangle/02_Graphics_pipeline_basics/01_Shader_modules.md
+++ b/en/03_Drawing_a_triangle/02_Graphics_pipeline_basics/01_Shader_modules.md
@@ -236,8 +236,8 @@ We're now going to compile these into SPIR-V bytecode using the
 Create a `compile.bat` file with the following contents:
 
 ```bash
-C:/VulkanSDK/x.x.x.x/Bin32/glslc.exe shader.vert -o vert.spv
-C:/VulkanSDK/x.x.x.x/Bin32/glslc.exe shader.frag -o frag.spv
+C:/VulkanSDK/x.x.x.x/Bin/glslc.exe shader.vert -o vert.spv
+C:/VulkanSDK/x.x.x.x/Bin/glslc.exe shader.frag -o frag.spv
 pause
 ```
 

--- a/fr/03_Dessiner_un_triangle/02_Pipeline_graphique_basique/01_Modules_shaders.md
+++ b/fr/03_Dessiner_un_triangle/02_Pipeline_graphique_basique/01_Modules_shaders.md
@@ -209,8 +209,8 @@ Nous allons maintenant compiler ces shaders en bytecode SPIR-V à l'aide du prog
 Créez un fichier `compile.bat` et copiez ceci dedans :
 
 ```bash
-C:/VulkanSDK/x.x.x.x/Bin32/glslc.exe shader.vert -o vert.spv
-C:/VulkanSDK/x.x.x.x/Bin32/glslc.exe shader.frag -o frag.spv
+C:/VulkanSDK/x.x.x.x/Bin/glslc.exe shader.vert -o vert.spv
+C:/VulkanSDK/x.x.x.x/Bin/glslc.exe shader.frag -o frag.spv
 pause
 ```
 


### PR DESCRIPTION
The latest Vulkan SDK doesn't have the `Bin32` directory.

For example, the path in 1.3.243.0 is:

```
C:/VulkanSDK/1.3.243.0/Bin/glslc.exe
```