### PR TITLE
Add another good Rust tutorial

### DIFF
--- a/en/00_Introduction.md
+++ b/en/00_Introduction.md
@@ -48,7 +48,7 @@ for a great introduction of computer graphics concepts. Some other great compute
 You can use C instead of C++ if you want, but you will have to use a different
 linear algebra library and you will be on your own in terms of code structuring.
 We will use C++ features like classes and RAII to organize logic and resource
-lifetimes. There are also two alternative versions of this tutorial available for Rust developers: [Vulkano based](https://github.com/bwasty/vulkan-tutorial-rs), [Vulkanalia based](https://github.com/KyleMayes/vulkanalia).
+lifetimes. There are also two alternative versions of this tutorial available for Rust developers: [Vulkano based](https://github.com/bwasty/vulkan-tutorial-rs), [Vulkanalia based](https://kylemayes.github.io/vulkanalia).
 
 To make it easier to follow along for developers using other programming languages, and to get some experience with the base API we'll be using the original C API to work with Vulkan. If you are using C++, however, you may prefer using the newer [Vulkan-Hpp](https://github.com/KhronosGroup/Vulkan-Hpp) bindings that abstract some of the dirty work and help prevent certain classes of errors.
 

--- a/en/00_Introduction.md
+++ b/en/00_Introduction.md
@@ -48,7 +48,7 @@ for a great introduction of computer graphics concepts. Some other great compute
 You can use C instead of C++ if you want, but you will have to use a different
 linear algebra library and you will be on your own in terms of code structuring.
 We will use C++ features like classes and RAII to organize logic and resource
-lifetimes. There is also an [alternative version](https://github.com/bwasty/vulkan-tutorial-rs) of this tutorial available for Rust developers.
+lifetimes. There are also two alternative versions of this tutorial available for Rust developers: [Vulkano based](https://github.com/bwasty/vulkan-tutorial-rs), [Vulkanalia based](https://github.com/KyleMayes/vulkanalia).
 
 To make it easier to follow along for developers using other programming languages, and to get some experience with the base API we'll be using the original C API to work with Vulkan. If you are using C++, however, you may prefer using the newer [Vulkan-Hpp](https://github.com/KhronosGroup/Vulkan-Hpp) bindings that abstract some of the dirty work and help prevent certain classes of errors.
 


### PR DESCRIPTION
The [vulkanalia-based tutorial](https://kylemayes.github.io/vulkanalia/) is
- Based on a much "lower level" crate `vulkanalia`, which is much closer to raw Vulkan API calls
- Also ships explanatory texts and discussed some Rust side practices
- *Completed*

Safe Rust is good, but it's also meaningful to have an alternative version, I think. Maybe we should even put the vulkanalia version ahead since it's more accomplished.