### PR TITLE
Update development environment tutorial for Linux to indicate possibl…

### DIFF
--- a/en/02_Development_environment.md
+++ b/en/02_Development_environment.md
@@ -219,6 +219,11 @@ include the Vulkan runtime and that your graphics card is supported. See the
 [introduction chapter](!en/Introduction) for links to drivers from the major
 vendors.
 
+### X Window System and XFree86-VidModeExtension
+It is possible that these libraries are not on the system, if not, you can install them using the following commands:
+* `sudo apt install libxxf86vm-dev` or `dnf install libXxf86vm-devel`: Provides an interface to the XFree86-VidModeExtension.
+* `sudo apt install libxi-dev` or `dnf install libXi-devel`: Provides an X Window System client interface to the XINPUT extension.
+
 ### GLFW
 
 As mentioned before, Vulkan by itself is a platform agnostic API and does not


### PR DESCRIPTION
…e libraries which may need to be installed.

On a fresh install of Ubuntu 22.04, I found that two additional libraries needed to be installed which were not provided by any of the previous package install commands shown in the tutorial. libxxf86vm-dev and libxi-dev. It's possible that these are commonly co-installed with other packages, but I put the commands to install them just to be explicit.