### PR TITLE
Add compute shader compilation to cmake

### DIFF
--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -28,8 +28,16 @@ function (add_shaders_target TARGET)
     OUTPUT ${SHADERS_DIR}
     COMMAND ${CMAKE_COMMAND} -E make_directory ${SHADERS_DIR}
     )
+    set (SHADERS ${SHADERS_DIR}/frag.spv ${SHADERS_DIR}/vert.spv)
+  # Some chapters may have compute shaders in addition to vertex and fragment shaders,
+  # so we conditionally check this and add them to the target
+  string(FIND "${SHADER_SOURCES}" "${CHAPTER_SHADER}.comp" COMPUTE_SHADER_INDEX)
+  if (${COMPUTE_SHADER_INDEX} GREATER -1)  
+    set (SHADERS ${SHADERS} ${SHADERS_DIR}/comp.spv)
+  endif()
+  MESSAGE(STATUS ${SHADERS})
   add_custom_command (
-    OUTPUT ${SHADERS_DIR}/frag.spv ${SHADERS_DIR}/vert.spv
+    OUTPUT ${SHADERS}
     COMMAND glslang::validator
     ARGS --target-env vulkan1.0 ${SHADER_SOURCES} --quiet
     WORKING_DIRECTORY ${SHADERS_DIR}
@@ -37,7 +45,7 @@ function (add_shaders_target TARGET)
     COMMENT "Compiling Shaders"
     VERBATIM
     )
-  add_custom_target (${TARGET} DEPENDS ${SHADERS_DIR}/frag.spv ${SHADERS_DIR}/vert.spv)
+  add_custom_target (${TARGET} DEPENDS ${SHADERS})
 endfunction ()
 
 function (add_chapter CHAPTER_NAME)
@@ -52,7 +60,7 @@ function (add_chapter CHAPTER_NAME)
 
   if (DEFINED CHAPTER_SHADER)
     set (CHAPTER_SHADER_TARGET ${CHAPTER_NAME}_shader)
-    file (GLOB SHADER_SOURCES ${CHAPTER_SHADER}.frag ${CHAPTER_SHADER}.vert)
+    file (GLOB SHADER_SOURCES ${CHAPTER_SHADER}.frag ${CHAPTER_SHADER}.vert ${CHAPTER_SHADER}.comp)
     add_shaders_target (${CHAPTER_SHADER_TARGET} CHAPTER_NAME ${CHAPTER_NAME} SOURCES ${SHADER_SOURCES})
     add_dependencies (${CHAPTER_NAME} ${CHAPTER_SHADER_TARGET})
   endif ()

--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -35,7 +35,6 @@ function (add_shaders_target TARGET)
   if (${COMPUTE_SHADER_INDEX} GREATER -1)  
     set (SHADERS ${SHADERS} ${SHADERS_DIR}/comp.spv)
   endif()
-  MESSAGE(STATUS ${SHADERS})
   add_custom_command (
     OUTPUT ${SHADERS}
     COMMAND glslang::validator

--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -28,7 +28,7 @@ function (add_shaders_target TARGET)
     OUTPUT ${SHADERS_DIR}
     COMMAND ${CMAKE_COMMAND} -E make_directory ${SHADERS_DIR}
     )
-    set (SHADERS ${SHADERS_DIR}/frag.spv ${SHADERS_DIR}/vert.spv)
+  set (SHADERS ${SHADERS_DIR}/frag.spv ${SHADERS_DIR}/vert.spv)
   # Some chapters may have compute shaders in addition to vertex and fragment shaders,
   # so we conditionally check this and add them to the target
   string(FIND "${SHADER_SOURCES}" "${CHAPTER_SHADER}.comp" COMPUTE_SHADER_INDEX)


### PR DESCRIPTION
This PR conditionally adds compute shaders to the build process. If such a shader type is present (e.g. for the compute bonus chapter) it's added to build such that the corresponding SPIR-V file will be generated at compile time.

Fixes #351 
Fixes #361 