### PR TITLE
Fix typo

### DIFF
--- a/fr/03_Dessiner_un_triangle/00_Mise_en_place/01_Instance.md
+++ b/fr/03_Dessiner_un_triangle/00_Mise_en_place/01_Instance.md
@@ -20,7 +20,7 @@ VkInstance instance;
 
 Pour créer l'instance, nous allons d'abord remplir une première structure avec des informations sur notre application.
 Ces données sont optionnelles, mais elles peuvent fournir des informations utiles au driver pour optimiser ou
-dignostiquer les erreurs lors de l'exécution, par exemple en reconnaissant le nom d'un moteur graphique. Cette structure
+diagnostiquer les erreurs lors de l'exécution, par exemple en reconnaissant le nom d'un moteur graphique. Cette structure
 s'appelle `VkApplicationInfo` :
 
 ```c++


### PR DESCRIPTION
[EN VERSION BELOW]

Vous avez oublié un "a" au mot "diagnostiquer".

[EN]

You forgot an "a" at "diagnostiquer"


```
di_a_gnostiquer les erreurs lors de l'exécution, par exemple en reconnaissant le nom d'un moteur graphique. Cette structure
```