### PR TITLE
Fix texture image view format

### DIFF
--- a/code/26_texture_mapping.cpp
+++ b/code/26_texture_mapping.cpp
@@ -755,7 +755,7 @@ private:
     }
 
     void createTextureImageView() {
-        textureImageView = createImageView(textureImage, VK_FORMAT_R8G8B8A8_SRGB);
+        textureImageView = createImageView(textureImage, swapChainImageFormat);
     }
 
     void createTextureSampler() {

--- a/code/27_depth_buffering.cpp
+++ b/code/27_depth_buffering.cpp
@@ -832,7 +832,7 @@ private:
     }
 
     void createTextureImageView() {
-        textureImageView = createImageView(textureImage, VK_FORMAT_R8G8B8A8_SRGB, VK_IMAGE_ASPECT_COLOR_BIT);
+        textureImageView = createImageView(textureImage, swapChainImageFormat, VK_IMAGE_ASPECT_COLOR_BIT);
     }
 
     void createTextureSampler() {

--- a/code/28_model_loading.cpp
+++ b/code/28_model_loading.cpp
@@ -839,7 +839,7 @@ private:
     }
 
     void createTextureImageView() {
-        textureImageView = createImageView(textureImage, VK_FORMAT_R8G8B8A8_SRGB, VK_IMAGE_ASPECT_COLOR_BIT);
+        textureImageView = createImageView(textureImage, swapChainImageFormat, VK_IMAGE_ASPECT_COLOR_BIT);
     }
 
     void createTextureSampler() {

--- a/code/29_mipmapping.cpp
+++ b/code/29_mipmapping.cpp
@@ -930,7 +930,7 @@ private:
     }
 
     void createTextureImageView() {
-        textureImageView = createImageView(textureImage, VK_FORMAT_R8G8B8A8_SRGB, VK_IMAGE_ASPECT_COLOR_BIT, mipLevels);
+        textureImageView = createImageView(textureImage, swapChainImageFormat, VK_IMAGE_ASPECT_COLOR_BIT, mipLevels);
     }
 
     void createTextureSampler() {

--- a/code/30_multisampling.cpp
+++ b/code/30_multisampling.cpp
@@ -980,7 +980,7 @@ private:
     }
 
     void createTextureImageView() {
-        textureImageView = createImageView(textureImage, VK_FORMAT_R8G8B8A8_SRGB, VK_IMAGE_ASPECT_COLOR_BIT, mipLevels);
+        textureImageView = createImageView(textureImage, swapChainImageFormat, VK_IMAGE_ASPECT_COLOR_BIT, mipLevels);
     }
 
     void createTextureSampler() {


### PR DESCRIPTION
The texture image view is set to VK_FORMAT_R8G8B8A8_SRGB. This should be changed to the swapChainImageFormat, since it is the format the image will be displayed in. If swapChainImageFormat is not equal to VK_FORMAT_R8G8B8A8_SRGB the final result will be incorrect (the colors will be off).