### PR TITLE
Update Chapter 2 to reflect that Arch Linux only has one glfw package now

### DIFF
--- a/en/02_Development_environment.md
+++ b/en/02_Development_environment.md
@@ -246,7 +246,7 @@ sudo dnf install glfw-devel
 ```
 or
 ```bash
-sudo pacman -S glfw-wayland # glfw-x11 for X11 users
+sudo pacman -S glfw
 ```
 
 ### GLM


### PR DESCRIPTION
Arch Linux doesn't have separate `glfw-wayland` and `glfw-x11` packages now. [(arch package search for "glfw")](https://archlinux.org/packages/?sort=&q=glfw&maintainer=&flagged=)