### PR TITLE
Replace mesa-vulkan-devel with mesa-vulkan-drivers in Fedora

### DIFF
--- a/en/02_Development_environment.md
+++ b/en/02_Development_environment.md
@@ -204,7 +204,7 @@ The most important components you'll need for developing Vulkan applications on 
 
 * `sudo apt install vulkan-tools` or `sudo dnf install vulkan-tools`: Command-line utilities, most importantly `vulkaninfo` and `vkcube`. Run these to confirm your machine supports Vulkan.
 * `sudo apt install libvulkan-dev` or `sudo dnf install vulkan-loader-devel` : Installs Vulkan loader. The loader looks up the functions in the driver at runtime, similarly to GLEW for OpenGL - if you're familiar with that.
-* `sudo apt install vulkan-validationlayers spirv-tools` or `sudo dnf install mesa-vulkan-devel vulkan-validation-layers-devel`: Installs the standard validation layers and required SPIR-V tools. These are crucial when debugging Vulkan applications, and we'll discuss them in the upcoming chapter.
+* `sudo apt install vulkan-validationlayers spirv-tools` or `sudo dnf install mesa-vulkan-drivers vulkan-validation-layers-devel`: Installs the standard validation layers and required SPIR-V tools. These are crucial when debugging Vulkan applications, and we'll discuss them in the upcoming chapter.
 
 On Arch Linux, you can run `sudo pacman -S vulkan-devel` to install all the
 required tools above.

--- a/fr/02_Environnement_de_développement.md
+++ b/fr/02_Environnement_de_développement.md
@@ -186,7 +186,7 @@ packages. Il vous faut un compilateur qui supporte C++17 (GCC 7+ ou Clang 5+). V
 Les composants les plus importants pour le développement d'applications Vulkan sous Linux sont le loader Vulkan, les validation layers et quelques utilitaires pour tester que votre machine est bien en état de faire fonctionner une application Vulkan:
 * `sudo apt install vulkan-tools` ou `sudo dnf install vulkan-tools`: Les utilitaires en ligne de commande, plus précisément `vulkaninfo` et `vkcube`. Lancez ceux-ci pour vérifier le bon fonctionnement de votre machine pour Vulkan.
 * `sudo apt install libvulkan-dev` ou `sudo dnf install vulkan-headers vulkan-loader-devel`: Installe le loader Vulkan. Il sert à aller chercher les fonctions auprès du driver de votre GPU au runtime, de la même façon que GLEW le fait pour OpenGL - si vous êtes familier avec ceci.
-* `sudo apt install vulkan-validationlayers-dev` ou `sudo dnf install mesa-vulkan-devel vulkan-validation-layers-devel`: Installe les layers de validation standards. Ceux-ci sont cruciaux pour débugger vos applications Vulkan, et nous en reparlerons dans un prochain chapitre.
+* `sudo apt install vulkan-validationlayers-dev` ou `sudo dnf install mesa-vulkan-drivers vulkan-validation-layers-devel`: Installe les layers de validation standards. Ceux-ci sont cruciaux pour débugger vos applications Vulkan, et nous en reparlerons dans un prochain chapitre.
 
 Si l'installation est un succès, vous devriez être prêt pour la partie Vulkan. N'oubliez pas de lancer `vkcube` et assurez-vous de voir la fenêtre suivante:
 


### PR DESCRIPTION
[EN]
The second section, called development environment, suggests to install the `mesa-vulkan-devel` on Fedora. This package does not exist since version 36. The current version is 41. It has been replaced with `mesa-vulkan-drivers`. I tested it. For an additional source, see : https://discussion.fedoraproject.org/t/what-is-the-f36-version-of-the-package-mesa-vulkan-devel/74573/4

[FR]
La seconde section, appelée « Environnement de développement », suggère d'installer le paquet `mesa-vulkan-devel` sur Fedora. Or ce paquet n'existe plus depuis la version 36. La version courante est la 41. Le paquet a été remplacé par `mesa-vulkan-drivers`. Je l'ai testé. Pour une source additionnelle, voir : https://discussion.fedoraproject.org/t/what-is-the-f36-version-of-the-package-mesa-vulkan-devel/74573/4