### PR TITLE
Remove invalid "warn" argument passed to tinyobj::loadObject(...)

### DIFF
--- a/code/28_model_loading.cpp
+++ b/code/28_model_loading.cpp
@@ -995,10 +995,10 @@ private:
         tinyobj::attrib_t attrib;
         std::vector<tinyobj::shape_t> shapes;
         std::vector<tinyobj::material_t> materials;
-        std::string warn, err;
+        std::string err;
 
-        if (!tinyobj::LoadObj(&attrib, &shapes, &materials, &warn, &err, MODEL_PATH.c_str())) {
-            throw std::runtime_error(warn + err);
+        if (!tinyobj::LoadObj(&attrib, &shapes, &materials, &err, MODEL_PATH.c_str())) {
+            throw std::runtime_error(err);
         }
 
         std::unordered_map<Vertex, uint32_t> uniqueVertices{};

--- a/code/29_mipmapping.cpp
+++ b/code/29_mipmapping.cpp
@@ -1089,10 +1089,10 @@ private:
         tinyobj::attrib_t attrib;
         std::vector<tinyobj::shape_t> shapes;
         std::vector<tinyobj::material_t> materials;
-        std::string warn, err;
+        std::string err;
 
-        if (!tinyobj::LoadObj(&attrib, &shapes, &materials, &warn, &err, MODEL_PATH.c_str())) {
-            throw std::runtime_error(warn + err);
+        if (!tinyobj::LoadObj(&attrib, &shapes, &materials, &err, MODEL_PATH.c_str())) {
+            throw std::runtime_error(err);
         }
 
         std::unordered_map<Vertex, uint32_t> uniqueVertices{};

--- a/code/30_multisampling.cpp
+++ b/code/30_multisampling.cpp
@@ -1139,10 +1139,10 @@ private:
         tinyobj::attrib_t attrib;
         std::vector<tinyobj::shape_t> shapes;
         std::vector<tinyobj::material_t> materials;
-        std::string warn, err;
+        std::string err;
 
-        if (!tinyobj::LoadObj(&attrib, &shapes, &materials, &warn, &err, MODEL_PATH.c_str())) {
-            throw std::runtime_error(warn + err);
+        if (!tinyobj::LoadObj(&attrib, &shapes, &materials, &err, MODEL_PATH.c_str())) {
+            throw std::runtime_error(err);
         }
 
         std::unordered_map<Vertex, uint32_t> uniqueVertices{};

--- a/en/08_Loading_models.md
+++ b/en/08_Loading_models.md
@@ -138,10 +138,10 @@ void loadModel() {
     tinyobj::attrib_t attrib;
     std::vector<tinyobj::shape_t> shapes;
     std::vector<tinyobj::material_t> materials;
-    std::string warn, err;
+    std::string err;
 
-    if (!tinyobj::LoadObj(&attrib, &shapes, &materials, &warn, &err, MODEL_PATH.c_str())) {
-        throw std::runtime_error(warn + err);
+    if (!tinyobj::LoadObj(&attrib, &shapes, &materials, &err, MODEL_PATH.c_str())) {
+        throw std::runtime_error(err);
     }
 }
 ```

--- a/fr/08_Charger_des_modèles.md
+++ b/fr/08_Charger_des_modèles.md
@@ -120,10 +120,10 @@ void loadModel() {
     tinyobj::attrib_t attrib;
     std::vector<tinyobj::shape_t> shapes;
     std::vector<tinyobj::material_t> materials;
-    std::string warn, err;
+    std::string err;
 
-    if (!tinyobj::LoadObj(&attrib, &shapes, &materials, &warn, &err, MODEL_PATH.c_str())) {
-        throw std::runtime_error(warn + err);
+    if (!tinyobj::LoadObj(&attrib, &shapes, &materials, &err, MODEL_PATH.c_str())) {
+        throw std::runtime_error(err);
     }
 }
 ```


### PR DESCRIPTION
Original issue: https://github.com/Overv/VulkanTutorial/issues/404

There is no function in the current implementation of TinyObjLoader which accepts more than one string in its arguments for error logging. Because of this, the unfixed example code causes a compilation failure.

To fix this, I removed the "warn" string passed to the tinyobj::loadObject(...) function, in the example code for chapters 28, 29, and 30; I also updated the code in both languages of the Loading Models chapter.