### PR TITLE
Optionally specify margin size (#396)

### DIFF
--- a/make_parser.py
+++ b/make_parser.py
@@ -1,0 +1,37 @@
+import argparse
+
+def make_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Build the pdf and epub files of the Vulkan Tutorial."
+    )
+
+    parser.add_argument(
+        "--geometry:left",
+        type=str,
+        required=False,
+        default="",
+        help="Specify left margin space as a string. Example: 2cm.",
+    )
+    parser.add_argument(
+        "--geometry:right",
+        type=str,
+        required=False,
+        default="",
+        help="Specify right margin space as a string. Example: 2cm.",
+    )
+    parser.add_argument(
+        "--geometry:top",
+        type=str,
+        required=False,
+        default="",
+        help="Specify top margin space as a string. Example: 2cm.",
+    )
+    parser.add_argument(
+        "--geometry:bottom",
+        type=str,
+        required=False,
+        default="",
+        help="Specify bottom margin space as a string. Example: 2cm.",
+    )
+
+    return parser


### PR DESCRIPTION
Whoever wants to shrink the margins, they can now do so via the new optional command line arguments

--geometry:left
--geometry:right
--geometry:top
--geometry:bottom

which are default options in pandoc (see pandoc's documentation [here](https://pandoc.org/demo/example33/6.2-variables.html)).

Their default value is ''. These options are not passed to pandoc when their value is ''.

The argument parser added can be extended easily with other pandoc's argument options. If the new options' default value is '' then they will not be passed to pandoc.