### PR TITLE
Fix typo in the html generation instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ necessary.
 Now with the above done, we can generate the static files. Asuming the daux.io
 and VulkanTutorial directories are next to each other, go into the `daux.io`
 directory and run a command similar to:
-`php generate -s ../VulkanTutorial -d ../VulkanTutorial/out`.
+`daux generate -s ../VulkanTutorial -d ../VulkanTutorial/out`.
 
 `-s` tells it where to find the documentation, while `-d` tells it where to put
 the generated files.

--- a/en/03_Drawing_a_triangle/00_Setup/00_Base_code.md
+++ b/en/03_Drawing_a_triangle/00_Setup/00_Base_code.md
@@ -145,8 +145,14 @@ disable it for now with another window hint call:
 glfwWindowHint(GLFW_RESIZABLE, GLFW_FALSE);
 ```
 
-All that's left now is creating the actual window. Add a `GLFWwindow* window;`
-private class member to store a reference to it and initialize the window with:
+All that's left now is creating the actual window. Add a private class member to store a reference to it:
+
+```c++
+private:
+GLFWwindow* window;
+```
+
+Initialize the window with
 
 ```c++
 window = glfwCreateWindow(800, 600, "Vulkan", nullptr, nullptr);


### PR DESCRIPTION
I was attempting to build the website following the directions in the ReadMe. I ran into several issues but this one I can confidently fix.

The "php" binary doesn't accept a "generate" command option but "daux" does. 