### PR TITLE
Add a code block for the GLFW window pointer.

### DIFF
--- a/en/03_Drawing_a_triangle/00_Setup/00_Base_code.md
+++ b/en/03_Drawing_a_triangle/00_Setup/00_Base_code.md
@@ -145,8 +145,14 @@ disable it for now with another window hint call:
 glfwWindowHint(GLFW_RESIZABLE, GLFW_FALSE);
 ```
 
-All that's left now is creating the actual window. Add a `GLFWwindow* window;`
-private class member to store a reference to it and initialize the window with:
+All that's left now is creating the actual window. Add a private class member to store a reference to it:
+
+```c++
+private:
+GLFWwindow* window;
+```
+
+Initialize the window with
 
 ```c++
 window = glfwCreateWindow(800, 600, "Vulkan", nullptr, nullptr);


### PR DESCRIPTION
Almost all of the code listed in this chapter uses a c++ code block. The block for the 'GLFWWindow* window' was missing.

I tried making a similar change to the French translation because it has the same issue but I don't speak French and using translation websites got me inconsistent answers.