### PR TITLE
Fix heading inside blockquote breaking PDF build

### DIFF
--- a/en/00_Introduction.md
+++ b/en/00_Introduction.md
@@ -1,4 +1,4 @@
->## Read before following this tutorial
+## Read before following this tutorial
 >
 >This tutorial was written shortly after Vulkan was initially released, back in
 >2016. A lot has changed since then and this tutorial no longer reflects the best


### PR DESCRIPTION
The "## Read before following this tutorial" heading in `en/00_Introduction.md` was placed inside a blockquote (`>`), which causes a LaTeX error when building the PDF

```
Error producing PDF.
! LaTeX Error: Something's wrong--perhaps a missing \item.

See the LaTeX manual or LaTeX Companion for explanation.
Type  H <return>  for immediate help.
 ...                                              
                                                  
l.119 \end{quote}
```

This happens because LaTeX doesn't allow a `\section` command inside a quote environment. The fix is to move the heading outside the blockquote 